### PR TITLE
fix links without text prop

### DIFF
--- a/src/components/blocks/rich_text/rich_text_section.tsx
+++ b/src/components/blocks/rich_text/rich_text_section.tsx
@@ -41,6 +41,8 @@ export const RichTextSectionElement = (props: RichTextSectionElementProps) => {
   if (element.type === "link") {
     const { url, style, text } = element;
 
+    // link elements may not have text prop when it is just a URL
+    const linkText = text || url;
     return (
       <a
         target="_blank"
@@ -55,7 +57,7 @@ export const RichTextSectionElement = (props: RichTextSectionElementProps) => {
           style?.bold ? "font-medium" : "",
         ])}
       >
-        {text}
+        {linkText}
       </a>
     );
   }

--- a/src/types/rich_text_element.ts
+++ b/src/types/rich_text_element.ts
@@ -84,7 +84,7 @@ export type RichTextSectionEmoji = {
 export type RichTextSectionLink = {
   type: "link";
   url: string;
-  text: string;
+  text?: string;
   style?: RichTextSectionElementStyleCode;
 };
 


### PR DESCRIPTION
When you just paste a URL in a Slack message, or use the RTE link button and leave the "Text" field blank, there is no `text` property on the `link` rich text element. The inner text of the resulting HTML should also be the URL. 
Currently, it displays nothing.

Example blocks:
```js
{
        "type": "rich_text_section",
        "elements": [
          {
            "type": "link",
            "url": "https://www.google.com/"
          },
          {
            "type": "link",
            "url": "https://www.google.com/",
            "text": "abc"
          }
        ]
 }
```