### PR TITLE
Provide default value for non standard field in users_select

### DIFF
--- a/src/components/elements/users_select_element.tsx
+++ b/src/components/elements/users_select_element.tsx
@@ -7,7 +7,15 @@ type TextObjectProps = {
 };
 
 export const UsersSelectElement = (props: TextObjectProps) => {
-  const { action_id, focus_on_load, placeholder, type, confirm, initial_user, people } = props.data;
+  const {
+    action_id,
+    focus_on_load,
+    placeholder,
+    type,
+    confirm,
+    initial_user,
+    people = [],
+  } = props.data;
   const [visible, setVisible] = useState(focus_on_load || false);
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState("");


### PR DESCRIPTION
Since the `people` prop is a non-Slack-standard field, it needs a default value (or null-check). Otherwise it breaks with a NPE at the `filter`.