### PR TITLE
Improve emoji parsing with unicode and skin-tone variants

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ This is the main component that renders the entire Slack message. It supports va
   - atChannel?: () = ReactNode
   - atEveryone?: () = ReactNode
   - atHere?: () = ReactNode
-  - emoji?: (name:string) => ReactNode | "fallback" (return "fallback" if you can't handle the emoji)
+  - emoji?: (data: { name: string; unicode?: string; skin_tone?: number; }, => ReactNode, fallback: (data: { name: string; unicode?: string; skin_tone?: number; }) => string )
   - date?: (data: { timestamp: string; format: string; link: string | null; fallback: string; }) => ReactNode;
 - `data?`: optionally pass an array or users, channels and user groups to automatically be replaced with the user, channel and user group mentions.
 - `showBlockKitDebug?`: Show a link to open the message in the Slack Block Kit Builder, for debugging purposes. Defaults to false.

--- a/src/components/blocks/rich_text/rich_text_section_emoji.tsx
+++ b/src/components/blocks/rich_text/rich_text_section_emoji.tsx
@@ -1,24 +1,64 @@
-import { RichTextSectionEmoji as RichTextSectionEmojiType } from "../../../types";
 import { useGlobalData } from "../../../store";
+import { RichTextSectionEmoji as RichTextSectionEmojiType } from "../../../types";
 import { parseEmojis } from "../../../utils";
 
 type Props = RichTextSectionEmojiType;
 
+type Emoji = Omit<RichTextSectionEmojiType, "type">;
+
+/**
+ * Convert a Unicode string to an emoji character
+ * e.g. "1f9d1-1f3fc-200d-2764-fe0f-200d-1f9d1-1f3fe" => 🫱🏻‍🫲🏾
+ * @param unicodeString - string of Unicode code points separated by hyphens
+ * @returns the emoji character represented by the Unicode string
+ */
+function convertUnicodeStrToEmoji(unicodeString: string) {
+  // convert the Unicode string to an array of code points (integers between 0 and 0x10FFFF, inclusive)
+  const codePoints = unicodeString.split("-").map((point) => parseInt(point, 16));
+
+  // convert the code points to an emoji character
+  const emoji = String.fromCodePoint(...codePoints);
+  return emoji;
+}
+
+/**
+ * Parse an emoji object into a string representation of the emoji
+ * @param params - the emoji object
+ * @param params.name - the name of the emoji
+ * @param params.skin_tone - the skin tone of the emoji, if applicable
+ * @param params.unicode - the Unicode code points of the emoji, if available
+ * @returns the string representation of the emoji
+ */
+function parseEmoji({ name, skin_tone, unicode }: Emoji): string {
+  // if the unicode is available, use it to render the emoji directly
+  if (unicode) {
+    const emojiFromUnicode = convertUnicodeStrToEmoji(unicode);
+    if (emojiFromUnicode) {
+      return emojiFromUnicode;
+    }
+  }
+
+  // fallback to emoji libs
+  // using the skin-tone variant, if present
+  const fullyQualifiedEmojiName = skin_tone ? `${name}::skin-tone-${skin_tone}` : name;
+  return parseEmojis(`:${fullyQualifiedEmojiName}:`);
+}
+
 export const RichTextSectionEmoji = (props: Props) => {
-  const { name } = props;
+  const emojiElement = props;
   const { hooks } = useGlobalData();
 
   if (hooks.emoji) {
     return (
       <span className="slack_blocks_to_jsx__rich_text_section_element_emoji">
-        {hooks.emoji(name, (name) => parseEmojis(`:${name}:`))}
+        {hooks.emoji(emojiElement, (emojiElement) => parseEmoji(emojiElement))}
       </span>
     );
   }
 
   return (
     <span className="slack_blocks_to_jsx__rich_text_section_element_emoji">
-      {parseEmojis(`:${name}:`)}
+      {parseEmoji(emojiElement)}
     </span>
   );
 };

--- a/src/store/useGlobalContext.tsx
+++ b/src/store/useGlobalContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode, useState } from "react";
+import React, { ReactNode, createContext, useContext, useState } from "react";
 
 type User = {
   id: string;
@@ -15,6 +15,14 @@ type UserGroup = {
   name: string;
 };
 
+type Emoji = {
+  name: string;
+  /* hyphen-delineated list of Unicode code points */
+  unicode?: string;
+  /* included only for single-color skintone emojis (not compound emojis) */
+  skin_tone?: 1 | 2 | 3 | 4 | 5 | 6;
+};
+
 type Hooks = {
   user?: (data: User) => ReactNode;
   channel?: (data: Channel) => ReactNode;
@@ -22,7 +30,13 @@ type Hooks = {
   atChannel?: () => ReactNode;
   atEveryone?: () => ReactNode;
   atHere?: () => ReactNode;
-  emoji?: (name: string, parse: (name: string) => string) => ReactNode;
+  /**
+   * The hook to replace emojis with custom components
+   * @param data - the emoji object
+   * @param parse - fallback function for default emoji parsing
+   * @returns the custom emoji component
+   */
+  emoji?: (data: Emoji, parse: (data: Emoji) => string) => ReactNode;
   date?: (data: {
     timestamp: string;
     format: string;

--- a/src/types/rich_text_element.ts
+++ b/src/types/rich_text_element.ts
@@ -80,6 +80,10 @@ export type RichTextSectionUser = {
 export type RichTextSectionEmoji = {
   type: "emoji";
   name: string;
+  /* hyphen-delineated list of Unicode code points */
+  unicode?: string;
+  /* included only for single-color skintone emojis (not compound emojis) */
+  skin_tone?: 1 | 2 | 3 | 4 | 5 | 6;
 };
 export type RichTextSectionLink = {
   type: "link";


### PR DESCRIPTION
Improves emoji parsing with unicode and skin-tone variants.
Slack has a couple very useful undocumented properties sent in the blocks for emoji elements, which we should use:
- `unicode`
- `skin_tone`

If the unicode is present, we should use it directly to render the emoji and skip the lookup. Otherwise, we should also include the `skin_tone` in the lookup.

===

**Example**:

🤟🏽🫱🏿‍🫲🏻
[Block Kit Builder example](https://app.slack.com/block-kit-builder/T060SL2GMU6#%7B%22blocks%22:%5B%7B%22type%22:%22rich_text%22,%22block_id%22:%229rSzr%22,%22elements%22:%5B%7B%22type%22:%22rich_text_section%22,%22elements%22:%5B%7B%22type%22:%22emoji%22,%22name%22:%22i_love_you_hand_sign%22,%22unicode%22:%221f91f-1f3fd%22,%22skin_tone%22:4%7D,%7B%22type%22:%22emoji%22,%22name%22:%22handshake%22,%22unicode%22:%221faf1-1f3ff-200d-1faf2-1f3fb%22%7D%5D%7D%5D%7D%5D%7D)
![Screenshot 2024-08-12 at 4 46 14 PM](https://github.com/user-attachments/assets/05746644-a9de-4815-b4d6-d48550384f8e)

Current bug:
![Screenshot 2024-08-12 at 4 46 23 PM](https://github.com/user-attachments/assets/44d8f51f-1264-40c5-bc79-c760cef3fe44)
