### PR TITLE
chore: update react support to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "node-emoji": "^2.1.3"
   },
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18"
+    "react": "^17 || ^18 || ^19",
+    "react-dom": "^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
-    "@types/react": "^17",
-    "@types/react-dom": "^17",
+    "@types/react": "^17 || ^18 || ^19",
+    "@types/react-dom": "^17 || ^18 || ^19",
     "autoprefixer": "^10.4.17",
     "cssnano": "^6.0.3",
     "postcss": "^8.4.33",


### PR DESCRIPTION
Update peer dependencies to allow resolution of React 19 and React DOM 19. I've done a survey of the repo to identify any breaking changes that impact the code, but it appears that none of the removed features were used in the codebase.

Resolves #53