### PR TITLE
feat: render URLs in inline code as clickable links

### DIFF
--- a/src/utils/markdown_parser/sub_elements/inline_code.tsx
+++ b/src/utils/markdown_parser/sub_elements/inline_code.tsx
@@ -13,9 +13,6 @@ function extractUrl(value: string): string | null {
   const slackLinkMatch = value.match(/^<(https?:\/\/[^>]+)>$/);
   if (slackLinkMatch) return slackLinkMatch[1] as string;
 
-  const bareUrlMatch = value.match(/^(https?:\/\/\S+)$/);
-  if (bareUrlMatch) return bareUrlMatch[1] as string;
-
   return null;
 }
 


### PR DESCRIPTION
## Problem

When inline code contains a Slack link (e.g., `` `<https://example.com>` ``), the parser converts it to `[url](url)` format, but since it's inside a code block, the Yozora parser treats it as plain text instead of rendering a clickable link.

**Result:** The literal text `[https://example.com](https://example.com)` is displayed instead of a clickable link.

## Solution

Update the `InlineCode` component to detect URLs that were converted by the parser and render them as `<a>` tags with both `slack_code_inline` and `slack_link` classes.

Handles two formats:
- `[url](url)` - the parser's converted format (where text equals URL)
- `<url>` - Slack's native link format