### PR TITLE
fix: convert LBKS placeholder to newlines in code blocks

### DIFF
--- a/src/utils/markdown_parser/elements/code.tsx
+++ b/src/utils/markdown_parser/elements/code.tsx
@@ -6,6 +6,7 @@ type Props = {
 
 export const Code = (props: Props) => {
   const { element } = props;
+  const value = element.value.replace(/LBKS/g, "\n");
 
-  return <code className="slack_code">{element.value}</code>;
+  return <code className="slack_code">{value}</code>;
 };


### PR DESCRIPTION
## Problem

The markdown parser uses `LBKS` as an internal placeholder for consecutive line breaks. However, this placeholder is not converted back to actual newlines when rendering code blocks, resulting in literal `LBKS` text appearing in the output.

## Solution

Replace `LBKS` with newlines in the `Code` component before rendering.