### PR TITLE
feat: Dark mode support

### DIFF
--- a/src/block_wrapper.tsx
+++ b/src/block_wrapper.tsx
@@ -8,7 +8,7 @@ export const BlockWrapper = (props: Props) => {
   const { children } = props;
 
   return (
-    <div className="text-base slack_blocks_to_jsx--block_wrapper break-words font-normal">
+    <div className="text-base slack_blocks_to_jsx--block_wrapper break-words font-normal dark:text-dark-text-primary dark:bg-dark-bg-primary">
       {children}
     </div>
   );

--- a/src/components/blocks/actions.tsx
+++ b/src/components/blocks/actions.tsx
@@ -11,7 +11,7 @@ export const Actions = (props: ActionsProps) => {
   return (
     <div
       id={block_id}
-      className="mb-2 text-primary flex w-full text-black-primary items-center slack_blocks_to_jsx__actions"
+      className="mb-2 text-primary flex w-full text-black-primary dark:text-dark-text-primary items-center slack_blocks_to_jsx__actions"
     >
       <div className="flex flex-wrap">
         {elements.map((element, i) => {

--- a/src/components/blocks/context.tsx
+++ b/src/components/blocks/context.tsx
@@ -12,12 +12,12 @@ export const Context = (props: ContextProps) => {
   return (
     <div
       id={block_id}
-      className="my-1 text-primary flex w-full text-black-primary flex-wrap items-center overflow-hidden slack_blocks_to_jsx__context"
+      className="my-1 text-primary flex w-full text-black-primary dark:text-dark-text-primary flex-wrap items-center overflow-hidden slack_blocks_to_jsx__context"
     >
       {elements.slice(0, 10).map((element, i) => {
         if (element.type !== "image") {
           return (
-            <div className="text-black-secondary text-small pr-3 flex items-center" key={i}>
+            <div className="text-black-secondary dark:text-dark-text-secondary text-small pr-3 flex items-center" key={i}>
               <TextObject data={element} />
             </div>
           );

--- a/src/components/blocks/divider.tsx
+++ b/src/components/blocks/divider.tsx
@@ -11,7 +11,7 @@ export const Divider = (props: DividerProps) => {
   return (
     <div
       id={block_id}
-      className="border-b border-gray-primary border-solid w-full mt-1 mb-2 slack_blocks_to_jsx__divider"
+      className="border-b border-gray-primary dark:border-dark-border border-solid w-full mt-1 mb-2 slack_blocks_to_jsx__divider"
     ></div>
   );
 };

--- a/src/components/blocks/header.tsx
+++ b/src/components/blocks/header.tsx
@@ -10,7 +10,7 @@ export const Header = (props: HeaderProps) => {
 
   return (
     <div id={block_id} className="mt-1 slack_blocks_to_jsx__header">
-      <h3 className="text-header font-bold slack_blocks_to_jsx__header_heading">
+      <h3 className="text-header font-bold text-black-primary dark:text-dark-text-primary slack_blocks_to_jsx__header_heading">
         <TextObject data={text} />
       </h3>
     </div>

--- a/src/components/blocks/image.tsx
+++ b/src/components/blocks/image.tsx
@@ -14,7 +14,7 @@ export const Image = (props: ImageProps) => {
 
   return (
     <div id={block_id} className="my-2 flex flex-col gap-2 slack_blocks_to_jsx__image">
-      <div className="slack_blocks_to_jsx__image_media_trigger text-black-secondary text-small flex gap-1 items-center">
+      <div className="slack_blocks_to_jsx__image_media_trigger text-black-secondary dark:text-dark-text-secondary text-small flex gap-1 items-center">
         {captionText && <span className="slack_blocks_to_jsx__image_title">{captionText}</span>}
         {image_bytes && (
           <span className="slack_blocks_to_jsx__image_size">
@@ -31,7 +31,7 @@ export const Image = (props: ImageProps) => {
             xmlns="http://www.w3.org/2000/svg"
             fillRule="evenodd"
             clipRule="evenodd"
-            className="text-blue-primary"
+            className="text-blue-primary dark:text-dark-link"
             imageRendering="optimizeQuality"
             shapeRendering="geometricPrecision"
             textRendering="geometricPrecision"

--- a/src/components/blocks/input.tsx
+++ b/src/components/blocks/input.tsx
@@ -14,7 +14,7 @@ export const Input = (props: InputProps) => {
   return (
     <div
       id={block_id}
-      className="mt-2 mb-1 text-primary slack_blocks_to_jsx__input flex w-full text-black-primary"
+      className="mt-2 mb-1 text-primary slack_blocks_to_jsx__input flex w-full text-black-primary dark:text-dark-text-primary"
     >
       <div className="grow">
         <div className="flex flex-col gap-2">
@@ -31,7 +31,7 @@ export const Input = (props: InputProps) => {
             <div className="relative shrink-0">{element}</div>
 
             {(hint || given_element?.type === "plain_text_input") && (
-              <div className="text-black-secondary text-small flex gap-1">
+              <div className="text-black-secondary dark:text-dark-text-secondary text-small flex gap-1">
                 {hint && (
                   <div className="inline">
                     <TextObject data={hint} />

--- a/src/components/blocks/rich_text/rich_text.tsx
+++ b/src/components/blocks/rich_text/rich_text.tsx
@@ -71,7 +71,7 @@ const Element = (props: ElementProps) => {
 
     return (
       <div className="flex gap-2 slack_blocks_to_jsx__rich_text_list_element">
-        {border === 1 && <div className="w-1 rounded bg-gray-primary self-stretch"></div>}
+        {border === 1 && <div className="w-1 rounded bg-gray-primary dark:bg-dark-text-high self-stretch"></div>}
 
         <RichTextListWrapper element={element} className="list-none">
           {elements.map((el, i) => {
@@ -130,10 +130,10 @@ const Element = (props: ElementProps) => {
 
     return (
       <code className="flex gap-2 w-full slack_blocks_to_jsx__rich_text_preformatted_element">
-        {border === 1 && <div className="w-1 rounded bg-gray-primary self-stretch"></div>}
+        {border === 1 && <div className="w-1 rounded bg-gray-primary dark:bg-dark-text-high self-stretch"></div>}
 
         <pre
-          className="p-2 rounded my-1 whitespace-pre-wrap bg-gray-secondary text-xs leading-[1.50001] border grow"
+          className="p-2 rounded my-1 whitespace-pre-wrap bg-gray-secondary dark:bg-dark-bg-secondary text-xs leading-[1.50001] border dark:border-dark-border grow"
           style={{
             wordWrap: "break-word",
             wordBreak: "break-all",
@@ -152,7 +152,7 @@ const Element = (props: ElementProps) => {
 
     return (
       <blockquote className="flex gap-2 slack_blocks_to_jsx__rich_text_quote_element">
-        {border === 1 && <div className="w-1 rounded bg-gray-primary self-stretch"></div>}
+        {border === 1 && <div className="w-1 rounded bg-gray-primary dark:bg-dark-text-high self-stretch"></div>}
 
         <p>
           {elements.map((el, i) => {

--- a/src/components/blocks/rich_text/rich_text_section_link.tsx
+++ b/src/components/blocks/rich_text/rich_text_section_link.tsx
@@ -20,7 +20,7 @@ export const RichTextSectionLink = (props: Props) => {
           rel: "noreferrer noopener",
           className: merge_classes([
             "slack_blocks_to_jsx__rich_text_section_element_link",
-            "text-blue-primary hover:underline underline-offset-4",
+            "text-blue-primary dark:text-dark-link hover:underline underline-offset-4",
             style?.italic ? "italic" : "",
             style?.strike ? "line-through" : "",
             style?.underline ? "underline" : "",
@@ -40,7 +40,7 @@ export const RichTextSectionLink = (props: Props) => {
       href={url}
       className={merge_classes([
         "slack_blocks_to_jsx__rich_text_section_element_link",
-        "text-blue-primary hover:underline underline-offset-4",
+        "text-blue-primary dark:text-dark-link hover:underline underline-offset-4",
         style?.italic ? "italic" : "",
         style?.strike ? "line-through" : "",
         style?.underline ? "underline" : "",

--- a/src/components/blocks/section.tsx
+++ b/src/components/blocks/section.tsx
@@ -17,7 +17,7 @@ export const Section = (props: SectionProps) => {
     <div
       id={block_id}
       className={merge_classes([
-        "mt-2 mb-1 text-primary slack_blocks_to_jsx__section flex w-full text-black-primary",
+        "mt-2 mb-1 text-primary slack_blocks_to_jsx__section flex w-full text-black-primary dark:text-dark-text-primary",
         is_stacked ? "flex-col" : "",
       ])}
     >

--- a/src/components/blocks/table.tsx
+++ b/src/components/blocks/table.tsx
@@ -18,7 +18,7 @@ export const Table = (props: TableProps) => {
   return (
     <div
       id={block_id}
-      className="mt-2 mb-1 slack_blocks_to_jsx__table inline-block border border-gray-300 rounded"
+      className="mt-2 mb-1 slack_blocks_to_jsx__table inline-block border border-gray-300 dark:border-dark-border rounded"
     >
       <table className="border-none">
         <tbody>
@@ -26,7 +26,7 @@ export const Table = (props: TableProps) => {
             <tr
               key={rowIndex}
               className={merge_classes([
-                "border-b border-gray-200",
+                "border-b border-gray-200 dark:border-dark-border",
                 rowIndex === rows.length - 1 ? "border-b-0" : "",
               ])}
             >
@@ -37,7 +37,7 @@ export const Table = (props: TableProps) => {
                 const isHeaderRow = rowIndex === 0;
 
                 const cellClasses = merge_classes([
-                  "px-3 py-2 border-r border-gray-200 last:border-r-0",
+                  "px-3 py-2 border-r border-gray-200 dark:border-dark-border last:border-r-0",
                   align === "center" ? "text-center" : "",
                   align === "right" ? "text-right" : "text-left",
                   isWrapped ? "break-words" : "whitespace-nowrap overflow-hidden text-ellipsis",

--- a/src/components/blocks/video.tsx
+++ b/src/components/blocks/video.tsx
@@ -24,18 +24,18 @@ export const Video = (props: VideoProps) => {
   return (
     <div className="py-2 slack_blocks_to_jsx__video" id={block_id}>
       {author_name && (
-        <div className="slack_blocks_to_jsx__video_author">
+        <div className="slack_blocks_to_jsx__video_author text-black-primary dark:text-dark-text-primary">
           <span className="font-bold">{author_name}</span>
         </div>
       )}
 
       {description && (
-        <div className="slack_blocks_to_jsx__video_description">
+        <div className="slack_blocks_to_jsx__video_description text-black-primary dark:text-dark-text-primary">
           <TextObject data={description} />
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-1 slack_blocks_to_jsx__video_title">
+      <div className="flex flex-wrap items-center gap-1 slack_blocks_to_jsx__video_title text-black-primary dark:text-dark-text-primary">
         {title_url ? (
           <RenderLink title={title} url={title_url} />
         ) : (
@@ -53,7 +53,7 @@ export const Video = (props: VideoProps) => {
             xmlns="http://www.w3.org/2000/svg"
             fillRule="evenodd"
             clipRule="evenodd"
-            className="text-blue-primary"
+            className="text-blue-primary dark:text-dark-link"
             imageRendering="optimizeQuality"
             shapeRendering="geometricPrecision"
             textRendering="geometricPrecision"
@@ -77,7 +77,7 @@ export const Video = (props: VideoProps) => {
         {showVideo && (
           <iframe
             title={alt_text}
-            className="max-w-[360px] bg-gray-100 w-full aspect-video"
+            className="max-w-[360px] bg-gray-100 dark:bg-dark-bg-secondary w-full aspect-video"
             src={video_url}
             {...iframeProps}
           />
@@ -96,7 +96,7 @@ const RenderLink = ({ url, title }: { url: string; title: TextObjectType<"plain_
         {hooks.link({
           href: url,
           children: <TextObject data={title} />,
-          className: "text-blue-primary",
+          className: "text-blue-primary dark:text-dark-link",
           rel: "noopener noreferrer",
           target: "_blank",
         })}
@@ -105,7 +105,7 @@ const RenderLink = ({ url, title }: { url: string; title: TextObjectType<"plain_
   }
 
   return (
-    <a href={url} className="text-blue-primary" target="_blank" rel="noopener noreferrer">
+    <a href={url} className="text-blue-primary dark:text-dark-link" target="_blank" rel="noopener noreferrer">
       <TextObject data={title} />
     </a>
   );

--- a/src/components/composition_objects/text_object.tsx
+++ b/src/components/composition_objects/text_object.tsx
@@ -16,13 +16,13 @@ export const TextObject = (props: TextObjectProps) => {
 
   if (type === "plain_text")
     return (
-      <div className={className}>
+      <div className={className + " dark:text-dark-text-primary"}>
         {markdown_parser(parsed, { markdown: false, verbatim, users, channels, hooks })}
       </div>
     );
 
   return (
-    <div className={className}>
+    <div className={className + " dark:text-dark-text-primary"}>
       {markdown_parser(parsed, { markdown: true, verbatim, users, channels, hooks })}
     </div>
   );

--- a/src/components/elements/button_element.tsx
+++ b/src/components/elements/button_element.tsx
@@ -23,7 +23,7 @@ export const ButtonElement = (props: TextObjectProps) => {
           ? "bg-green-primary text-white-primary"
           : style === "danger"
           ? "bg-red-primary text-white-primary"
-          : "border-black-primary.3 text-black-primary",
+          : "border-black-primary.3 text-black-primary dark:border-dark-border dark:text-dark-text-primary",
       ])}
       onClick={() => {
         if (url) {

--- a/src/components/elements/checkboxes_element.tsx
+++ b/src/components/elements/checkboxes_element.tsx
@@ -52,7 +52,7 @@ export const CheckboxesElement = (props: TextObjectProps) => {
 
               <div>
                 <TextObject data={text} />
-                {description && <TextObject className="text-black-secondary" data={description} />}
+                {description && <TextObject className="text-black-secondary dark:text-dark-text-secondary" data={description} />}
               </div>
             </label>
           );

--- a/src/components/elements/plain_text_input.tsx
+++ b/src/components/elements/plain_text_input.tsx
@@ -47,13 +47,13 @@ export const PlaintTextInput = (props: TextObjectProps) => {
       tabIndex={0}
     >
       {!value && placeholder && (
-        <div className="absolute left-2 top-2 text-black-primary.3">
+        <div className="absolute left-2 top-2 text-black-primary.3 dark:text-dark-text-secondary">
           <TextObject data={placeholder} />
         </div>
       )}
 
       {!value && !placeholder && (
-        <div className="absolute left-2 top-2 text-black-primary.3">
+        <div className="absolute left-2 top-2 text-black-primary.3 dark:text-dark-text-secondary">
           <TextObject
             data={{
               type: "plain_text",
@@ -66,7 +66,7 @@ export const PlaintTextInput = (props: TextObjectProps) => {
       <textarea
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        className="w-full focus:outline-none rounded border border-black-primary.3 p-2"
+        className="w-full focus:outline-none rounded border border-black-primary.3 dark:border-dark-border dark:bg-dark-bg-secondary dark:text-dark-text-primary p-2"
         minLength={min_length}
         maxLength={max_length}
         style={{

--- a/src/components/elements/static_select_element.tsx
+++ b/src/components/elements/static_select_element.tsx
@@ -51,12 +51,12 @@ export const StaticSelectElement = (props: TextObjectProps) => {
   return (
     <div
       id={action_id}
-      className="py-1 px-2 h-7 min-h-[28px] relative flex items-center justify-between rounded text-small w-[190px] border border-black-primary.3"
+      className="py-1 px-2 h-7 min-h-[28px] relative flex items-center justify-between rounded text-small w-[190px] border border-black-primary.3 dark:border-dark-border dark:bg-dark-bg-secondary dark:text-dark-text-primary"
       tabIndex={0}
     >
       {visible && (
         <div
-          className="absolute top-[24px] -left-3 bg-white-secondary border border-gray-primary rounded-[6px] shadow-custom_shadow-1 w-[322px] max-w-[322px] max-h-[240px] overflow-auto py-3 z-20"
+          className="absolute top-[24px] -left-3 bg-white-secondary dark:bg-dark-bg-secondary border border-gray-primary dark:border-dark-border rounded-[6px] shadow-custom_shadow-1 w-[322px] max-w-[322px] max-h-[240px] overflow-auto py-3 z-20"
           id="static_select_popup"
         >
           <div className="flex flex-col">
@@ -64,7 +64,7 @@ export const StaticSelectElement = (props: TextObjectProps) => {
               return (
                 <div
                   key={i}
-                  className="h-7 px-6 flex items-center select-none cursor-pointer hover:bg-blue-primary hover:text-white-primary"
+                  className="h-7 px-6 flex items-center select-none cursor-pointer hover:bg-blue-primary hover:text-white-primary dark:hover:bg-dark-link"
                   tabIndex={0}
                   onClick={() => {
                     setVisible(false);
@@ -83,13 +83,13 @@ export const StaticSelectElement = (props: TextObjectProps) => {
         type="text"
         value={search}
         onChange={(e) => setSearch(e.currentTarget.value)}
-        className="w-full py-1 pr-7 focus:outline-none"
+        className="w-full py-1 pr-7 focus:outline-none dark:bg-dark-bg-secondary dark:text-dark-text-primary"
         tabIndex={-1}
         aria-label="Select an item"
       />
 
       {!search && (
-        <div className="absolute w-full h-full pointer-events-none flex items-center text-black-primary.3">
+        <div className="absolute w-full h-full pointer-events-none flex items-center text-black-primary.3 dark:text-dark-text-secondary">
           <TextObject
             data={
               placeholder ?? {
@@ -103,7 +103,7 @@ export const StaticSelectElement = (props: TextObjectProps) => {
 
       <button
         type="button"
-        className="absolute right-1 top-1/2 flex justify-center items-center w-5 -translate-y-1/2 text-black-secondary z-10 h-full"
+        className="absolute right-1 top-1/2 flex justify-center items-center w-5 -translate-y-1/2 text-black-secondary dark:text-dark-text-secondary z-10 h-full"
         id="static_select_dropdown_button"
         onClick={() => {
           setVisible((prev) => !prev);

--- a/src/components/elements/users_select_element.tsx
+++ b/src/components/elements/users_select_element.tsx
@@ -50,12 +50,12 @@ export const UsersSelectElement = (props: TextObjectProps) => {
   return (
     <div
       id={action_id}
-      className="py-1 px-2 h-7 min-h-[28px] relative flex items-center justify-between rounded text-small w-[190px] border border-black-primary.3 slack_blocks_to_jsx__users_select_element"
+      className="py-1 px-2 h-7 min-h-[28px] relative flex items-center justify-between rounded text-small w-[190px] border border-black-primary.3 dark:border-dark-border dark:bg-dark-bg-secondary dark:text-dark-text-primary slack_blocks_to_jsx__users_select_element"
       tabIndex={0}
     >
       {visible && (
         <div
-          className="absolute top-[24px] -left-3 bg-white-secondary border border-gray-primary rounded-[6px] shadow-custom_shadow-1 w-[322px] max-w-[322px] max-h-[240px] overflow-auto py-3 z-20"
+          className="absolute top-[24px] -left-3 bg-white-secondary dark:bg-dark-bg-secondary border border-gray-primary dark:border-dark-border rounded-[6px] shadow-custom_shadow-1 w-[322px] max-w-[322px] max-h-[240px] overflow-auto py-3 z-20"
           id="static_select_popup"
         >
           <div className="flex flex-col">
@@ -63,7 +63,7 @@ export const UsersSelectElement = (props: TextObjectProps) => {
               return (
                 <button
                   key={i}
-                  className="h-7 px-6 flex group items-center gap-2 select-none cursor-pointer hover:bg-blue-primary hover:text-white-primary"
+                  className="h-7 px-6 flex group items-center gap-2 select-none cursor-pointer hover:bg-blue-primary hover:text-white-primary dark:hover:bg-dark-link"
                   tabIndex={0}
                   type="button"
                   onClick={() => {
@@ -79,7 +79,7 @@ export const UsersSelectElement = (props: TextObjectProps) => {
                     />
                   )}
                   {!option.image && (
-                    <div className="w-5 h-5 rounded-md overflow-hidden bg-gray-300 text-black-primary font-semibold flex items-center justify-center">
+                    <div className="w-5 h-5 rounded-md overflow-hidden bg-gray-300 dark:bg-dark-text-high text-black-primary dark:text-dark-text-primary font-semibold flex items-center justify-center">
                       <span>{option.name[0] || ""}</span>
                     </div>
                   )}
@@ -107,7 +107,7 @@ export const UsersSelectElement = (props: TextObjectProps) => {
                     )}
                   </div>
 
-                  <div className="text-black-primary group-hover:text-white-primary">
+                  <div className="text-black-primary dark:text-dark-text-primary group-hover:text-white-primary">
                     {option.name}
                   </div>
                 </button>
@@ -122,13 +122,13 @@ export const UsersSelectElement = (props: TextObjectProps) => {
         value={search}
         onClick={() => setVisible(true)}
         onChange={(e) => setSearch(e.currentTarget.value)}
-        className="w-full py-1 pr-7 focus:outline-none"
+        className="w-full py-1 pr-7 focus:outline-none dark:bg-dark-bg-secondary dark:text-dark-text-primary"
         tabIndex={-1}
         aria-label="Select an item"
       />
 
       {!search && (
-        <div className="absolute w-full h-full pointer-events-none flex items-center text-black-primary.3">
+        <div className="absolute w-full h-full pointer-events-none flex items-center text-black-primary.3 dark:text-dark-text-secondary">
           <TextObject
             data={
               placeholder ?? {
@@ -142,7 +142,7 @@ export const UsersSelectElement = (props: TextObjectProps) => {
 
       <button
         type="button"
-        className="absolute right-1 top-1/2 flex justify-center items-center w-5 -translate-y-1/2 text-black-secondary z-10 h-full"
+        className="absolute right-1 top-1/2 flex justify-center items-center w-5 -translate-y-1/2 text-black-secondary dark:text-dark-text-secondary z-10 h-full"
         id="static_select_dropdown_button"
         onClick={() => {
           setVisible((prev) => !prev);

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -10,11 +10,11 @@ export const Header = (props: Props) => {
 
   return (
     <div className="flex gap-[5px] items-center w-full slack_blocks_to_jsx--header">
-      <h3 className="font-black text-[15px]">{name}</h3>
-      <div className="h-[14px] w-[27px] leading-[12.5px] py-[1px] px-[3px] uppercase text-[10px]  text-black-primary/[0.7] bg-black-primary/[0.13] font-semibold rounded-[2px] text-center">
+      <h3 className="font-black text-[15px] dark:text-dark-text-primary">{name}</h3>
+      <div className="h-[14px] w-[27px] leading-[12.5px] py-[1px] px-[3px] uppercase text-[10px] text-black-primary/[0.7] bg-black-primary/[0.13] dark:text-dark-text-primary/[0.7] dark:bg-dark-text-primary/[0.13] font-semibold rounded-[2px] text-center">
         APP
       </div>
-      <div className="text-xs text-black-secondary uppercase leading-[17.6px]">
+      <div className="text-xs text-black-secondary dark:text-dark-text-secondary uppercase leading-[17.6px]">
         {dateToTime(time)}
       </div>
     </div>

--- a/src/message.tsx
+++ b/src/message.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { BlockWrapper } from "./block_wrapper";
 import { getBlockComponent } from "./components";
 import { Header } from "./header";
@@ -7,7 +8,7 @@ import { merge_classes } from "./utils";
 
 type Props = {
   /**
-   * Not yet implemented.
+   * Theme mode for the component. If not specified, system preference is used.
    */
   theme?: "light" | "dark";
   /**
@@ -48,13 +49,31 @@ export const Message = (props: Props) => {
     data,
     hooks,
     withoutWrapper = false,
+    theme,
   } = props;
+
+  const [systemPrefersDark, setSystemPrefersDark] = useState(false);
+
+  useEffect(() => {
+    if (theme === undefined) {
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      setSystemPrefersDark(mediaQuery.matches);
+
+      const handler = (e: MediaQueryListEvent) => setSystemPrefersDark(e.matches);
+      mediaQuery.addEventListener("change", handler);
+
+      return () => mediaQuery.removeEventListener("change", handler);
+    }
+  }, [theme]);
+
+  const activeTheme = theme ?? (systemPrefersDark ? "dark" : "light");
 
   if (withoutWrapper) {
     return (
       <GlobalProvider data={data} hooks={hooks}>
         <div
           id="slack_blocks_to_jsx"
+          data-theme={activeTheme}
           className={merge_classes([
             "slack_blocks_to_jsx relative flex gap-2 w-full max-w-[600px]",
             unstyled ? "styles_disabled" : "styles_enabled",
@@ -79,9 +98,10 @@ export const Message = (props: Props) => {
 
   return (
     <GlobalProvider data={data} hooks={hooks}>
-      <div id="slack_blocks_to_jsx">
+      <div id="slack_blocks_to_jsx" data-theme={activeTheme} className="dark:text-dark-text-primary dark:bg-dark-bg-primary">
         <section
           className={merge_classes([
+            "dark:text-dark-text-primary dark:bg-dark-bg-primary",
             "slack_blocks_to_jsx relative flex gap-2 w-full max-w-[600px]",
             unstyled ? "styles_disabled" : "styles_enabled",
             className,

--- a/src/style.css
+++ b/src/style.css
@@ -309,15 +309,15 @@
 
   /* #region CUSTOM STYLES */
   & .slack_code_inline {
-    @apply inline-block px-1 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] text-red-primary font-mono;
+    @apply inline-block px-1 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] text-red-primary dark:text-orange-primary font-mono dark:border-dark-code-border dark:bg-dark-code-bg;
   }
 
   & .slack_code {
-    @apply block p-2 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] w-full my-1 font-mono;
+    @apply block p-2 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] w-full my-1 font-mono dark:border-dark-code-border dark:bg-dark-code-bg dark:text-dark-text-primary;
   }
 
   & .slack_inline_code {
-    @apply inline-block px-[3px] text-xs pt-0.5 pb-px whitespace-pre-wrap break-words text-red-primary rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] font-mono;
+    @apply inline-block px-[3px] text-xs pt-0.5 pb-px whitespace-pre-wrap break-words text-red-primary dark:text-orange-primary rounded-[3px] border border-black-primary/[0.13] bg-black-primary/[0.04] font-mono dark:border-dark-code-border dark:bg-dark-code-bg;
   }
 
   & .slack_bold code {
@@ -350,7 +350,7 @@
   }
 
   & blockquote::before {
-    background: rgb(221, 221, 221);
+    @apply bg-gray-primary dark:bg-dark-text-high;
     content: "";
     border-radius: 8px;
     width: 4px;
@@ -361,28 +361,14 @@
     left: 0;
   }
 
-  & .slack_user {
-    color: rgb(18, 100, 163);
-    background: rgb(29, 155, 209, 0.1);
-    user-select: none;
-  }
-
-  & .slack_channel {
-    color: rgb(18, 100, 163);
-    background: rgb(29, 155, 209, 0.1);
-    user-select: none;
-  }
-
+  & .slack_user,
+  & .slack_channel,
   & .slack_user_group {
-    color: rgb(18, 100, 163);
-    background: rgb(29, 155, 209, 0.1);
-    user-select: none;
+    @apply text-blue-primary bg-blue-primary/10 dark:text-dark-user-text dark:bg-dark-user-bg select-none;
   }
 
   & .slack_broadcast {
-    color: rgb(29, 28, 29);
-    background: rgba(255, 198, 0, 0.18);
-    font-weight: 600;
+    @apply text-broadcast-text bg-broadcast-bg font-semibold dark:text-dark-broadcast-text dark:bg-dark-broadcast-bg;
   }
 
   & .slack_blocks_to_jsx__line_break {
@@ -394,7 +380,7 @@
   }
 
   & .slack_link {
-    color: rgb(18, 100, 163);
+    @apply text-blue-primary dark:text-dark-link;
   }
 
   /* #endregion */

--- a/src/utils/markdown_parser/elements/blockquote.tsx
+++ b/src/utils/markdown_parser/elements/blockquote.tsx
@@ -10,7 +10,7 @@ export const Blockquote = (props: Props) => {
 
   return (
     <div className="flex gap-2">
-      <div className="w-1 rounded bg-gray-primary self-stretch"></div>
+      <div className="w-1 rounded bg-gray-primary dark:bg-dark-text-high self-stretch"></div>
 
       <div>
         {element.children.map((para, i) => {

--- a/src/utils/markdown_parser/elements/code.tsx
+++ b/src/utils/markdown_parser/elements/code.tsx
@@ -7,5 +7,5 @@ type Props = {
 export const Code = (props: Props) => {
   const { element } = props;
 
-  return <code className="slack_code">{element.value}</code>;
+  return <code className="slack_code block p-2 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] dark:border-dark-code-border bg-black-primary/[0.04] dark:bg-dark-code-bg dark:text-dark-text-primary w-full my-1 font-mono">{element.value}</code>;
 };

--- a/src/utils/markdown_parser/sub_elements/inline_code.tsx
+++ b/src/utils/markdown_parser/sub_elements/inline_code.tsx
@@ -72,7 +72,7 @@ export const InlineCode = (props: Props) => {
         href={firstPart.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="slack_code_inline hover:underline"
+        className="slack_code_inline inline-block px-1 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] dark:border-dark-code-border bg-black-primary/[0.04] dark:bg-dark-code-bg text-red-primary dark:text-dark-text-primary font-mono hover:underline"
       >
         {firstPart.label}
       </a>
@@ -81,7 +81,7 @@ export const InlineCode = (props: Props) => {
 
   // If there are no links, just render as plain code
   if (parts.every((part) => part.type === "text")) {
-    return <code className="slack_code_inline">{element.value}</code>;
+    return <code className="slack_code_inline inline-block px-1 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] dark:border-dark-code-border bg-black-primary/[0.04] dark:bg-dark-code-bg text-red-primary dark:text-dark-text-primary font-mono">{element.value}</code>;
   }
 
   // Mixed content: render code with embedded links
@@ -95,12 +95,12 @@ export const InlineCode = (props: Props) => {
         href={part.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="hover:underline"
+        className="hover:underline text-blue-primary dark:text-dark-link"
       >
         {part.label}
       </a>
     );
   });
 
-  return <code className="slack_code_inline">{children}</code>;
+  return <code className="slack_code_inline inline-block px-1 text-xs whitespace-pre-wrap break-words rounded-[3px] border border-black-primary/[0.13] dark:border-dark-code-border bg-black-primary/[0.04] dark:bg-dark-code-bg text-red-primary dark:text-dark-text-primary font-mono">{children}</code>;
 };

--- a/src/utils/markdown_parser/sub_elements/slack_broadcast.tsx
+++ b/src/utils/markdown_parser/sub_elements/slack_broadcast.tsx
@@ -13,5 +13,5 @@ export const SlackBroadcast = (props: Props) => {
   if (element.value === "everyone" && hooks.atEveryone) return <>{hooks.atEveryone()}</>;
   if (element.value === "channel" && hooks.atChannel) return <>{hooks.atChannel()}</>;
 
-  return <span className="slack_broadcast">@{element.value}</span>;
+  return <span className="slack_broadcast text-broadcast-text dark:text-dark-broadcast-text bg-broadcast-bg dark:bg-dark-broadcast-bg font-semibold">@{element.value}</span>;
 };

--- a/src/utils/markdown_parser/sub_elements/slack_channel_mention.tsx
+++ b/src/utils/markdown_parser/sub_elements/slack_channel_mention.tsx
@@ -29,7 +29,7 @@ export const SlackChannelMention = (props: Props) => {
   }
 
   return (
-    <span className="slack_channel" data-channel-id={channel?.id || channel_id}>
+    <span className="slack_channel text-blue-primary dark:text-dark-user-text bg-blue-primary/10 dark:bg-dark-user-bg select-none" data-channel-id={channel?.id || channel_id}>
       #{label}
     </span>
   );

--- a/src/utils/markdown_parser/sub_elements/slack_date.tsx
+++ b/src/utils/markdown_parser/sub_elements/slack_date.tsx
@@ -69,7 +69,7 @@ const WrapWithLink = (props: { wrap: boolean; href: string; children: ReactNode 
         {hooks.link({
           href: props.href,
           children: props.children,
-          className: "text-blue-primary",
+          className: "text-blue-primary dark:text-dark-link",
           rel: "noopener noreferrer",
           target: "_blank",
         })}
@@ -78,7 +78,7 @@ const WrapWithLink = (props: { wrap: boolean; href: string; children: ReactNode 
   }
 
   return (
-    <a href={props.href} target="_blank" rel="noopener noreferrer" className="text-blue-primary">
+    <a href={props.href} target="_blank" rel="noopener noreferrer" className="text-blue-primary dark:text-dark-link">
       {props.children}
     </a>
   );

--- a/src/utils/markdown_parser/sub_elements/slack_user_group_mention.tsx
+++ b/src/utils/markdown_parser/sub_elements/slack_user_group_mention.tsx
@@ -16,7 +16,7 @@ export const SlackUserGroupMention = (props: Props) => {
   if (hooks.usergroup) return <>{hooks.usergroup(group || { id: group_id, name: label })}</>;
 
   return (
-    <span data-usergroup-id={group?.id || group_id} className="slack_user_group">
+    <span data-usergroup-id={group?.id || group_id} className="slack_user_group text-blue-primary dark:text-dark-user-text bg-blue-primary/10 dark:bg-dark-user-bg select-none">
       @{label}
     </span>
   );

--- a/src/utils/markdown_parser/sub_elements/slack_user_mention.tsx
+++ b/src/utils/markdown_parser/sub_elements/slack_user_mention.tsx
@@ -15,7 +15,7 @@ export const SlackUserMention = (props: Props) => {
   const label = user?.name || user_id;
 
   return (
-    <span className="slack_user" data-user-id={user?.id || user_id}>
+    <span className="slack_user text-blue-primary dark:text-dark-user-text bg-blue-primary/10 dark:bg-dark-user-bg select-none" data-user-id={user?.id || user_id}>
       @{label}
     </span>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	important:"#slack_blocks_to_jsx",
+	darkMode: ['selector', '[data-theme="dark"]'],
 	content: [
 		"./src/**/*.{js,ts,jsx,tsx,mdx}",
 	],
@@ -27,6 +28,9 @@ module.exports = {
 					primary: " rgb(224, 30, 90)",
 					"primary.3": "rgba(224, 30, 90, 0.3)",
 				},
+				orange: {
+					primary: "rgb(232, 145, 45)",
+				},
 				blue: {
 					primary: "rgb(18,100,163)",
 					secondary: "rgb(11, 76, 140)"
@@ -35,6 +39,38 @@ module.exports = {
 					primary: "rgb(0, 122, 90)",
 					"primary.3": "rgba(0, 122, 90, 0.3)",
 					secondary:"rgb(32, 162, 113)"
+				},
+				broadcast: {
+					text: "rgb(29, 28, 29)",
+					bg: "rgba(244, 196, 0, 0.18)",
+				},
+				dark: {
+					bg: {
+						primary: "rgb(26, 29, 33)",
+						secondary: "rgb(35, 37, 39)",
+					},
+					text: {
+						primary: "rgb(209, 210, 211)",
+						secondary: "rgb(171, 172, 173)",
+						max: "rgb(154, 156, 158)",
+						high: "rgb(117, 119, 122)",
+						low: "rgb(50, 53, 56)",
+						min: "rgb(33, 36, 40)",
+					},
+					border: "rgb(84, 84, 84)",
+					link: "rgb(29, 155, 209)",
+					code: {
+						bg: "rgb(33, 36, 40)",
+						border: "rgb(50, 53, 56)",
+					},
+					user: {
+						bg: "rgba(29, 155, 209, 0.2)",
+						text: "rgb(29, 155, 209)",
+					},
+					broadcast: {
+						text: "rgb(222, 167, 0)",
+						bg: "rgba(222, 167, 0, 0.18)",
+					},
 				},
 			},
 			fontSize: {


### PR DESCRIPTION
Implements color mode support. Supports retrieving default theme from system and falling back to light theme when not specified. Color mode can be overridden by providing either `light` or `dark` for the theme in the `Message` component.

Updates Tailwind theme to add official colors used by the Block Kit Builder for the dark color mode and utilizes those colors with Tailwind's dark mode support.

See related PR: 

Light:
<img width="469" height="883" alt="image" src="https://github.com/user-attachments/assets/4c99d35d-ab28-4ca6-9ca5-7ce549ca253e" />

Dark:
<img width="473" height="887" alt="image" src="https://github.com/user-attachments/assets/9cad53eb-1534-42b9-ae68-9269b2f65fa1" />
