### PR TITLE
fix: scope tailwind --tw-* reset to #slack_blocks_to_jsx

### DIFF
--- a/.changeset/fix-transform-reset-selector-scope.md
+++ b/.changeset/fix-transform-reset-selector-scope.md
@@ -1,5 +1,0 @@
----
-"slack-blocks-to-jsx": patch
----
-
-Fix select dropdown chevrons (and any other `transform`-based utility) rendering with no transform applied. The Tailwind `--tw-*` variable reset was scoped to `.slack_blocks_to_jsx.styles_enabled`, while the utility classes themselves are scoped to `#slack_blocks_to_jsx` (per `tailwind.config.js#important`). When the two scopes didn't align, the variables stayed unset and the browser dropped the resulting `transform: translate( , ) rotate( ) …` declaration as invalid. The reset is now scoped to `#slack_blocks_to_jsx` so it always matches the same elements as the generated utility classes.

--- a/.changeset/fix-transform-reset-selector-scope.md
+++ b/.changeset/fix-transform-reset-selector-scope.md
@@ -1,0 +1,5 @@
+---
+"slack-blocks-to-jsx": patch
+---
+
+Fix select dropdown chevrons (and any other `transform`-based utility) rendering with no transform applied. The Tailwind `--tw-*` variable reset was scoped to `.slack_blocks_to_jsx.styles_enabled`, while the utility classes themselves are scoped to `#slack_blocks_to_jsx` (per `tailwind.config.js#important`). When the two scopes didn't align, the variables stayed unset and the browser dropped the resulting `transform: translate( , ) rotate( ) …` declaration as invalid. The reset is now scoped to `#slack_blocks_to_jsx` so it always matches the same elements as the generated utility classes.

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,66 @@
 @tailwind utilities;
 
+/*
+ * Tailwind transform/filter/ring/etc. utilities reference --tw-* custom properties
+ * that must be initialized for the resulting `transform: translate(var(--tw-translate-x), ...)`
+ * declaration to be valid. Scope the reset to #slack_blocks_to_jsx so it matches the
+ * same elements as the generated utility classes (config.important is "#slack_blocks_to_jsx"),
+ * rather than coupling it to the optional .styles_enabled class.
+ */
+#slack_blocks_to_jsx,
+#slack_blocks_to_jsx *,
+#slack_blocks_to_jsx ::backdrop,
+#slack_blocks_to_jsx :after,
+#slack_blocks_to_jsx :before {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #3b82f680;
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+}
+
 .slack_blocks_to_jsx.styles_enabled {
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
@@ -258,59 +319,6 @@
 
   & [hidden] {
     display: none;
-  }
-
-  & *,
-  & ::backdrop,
-  & :after,
-  & :before {
-    --tw-border-spacing-x: 0;
-    --tw-border-spacing-y: 0;
-    --tw-translate-x: 0;
-    --tw-translate-y: 0;
-    --tw-rotate: 0;
-    --tw-skew-x: 0;
-    --tw-skew-y: 0;
-    --tw-scale-x: 1;
-    --tw-scale-y: 1;
-    --tw-pan-x: ;
-    --tw-pan-y: ;
-    --tw-pinch-zoom: ;
-    --tw-scroll-snap-strictness: proximity;
-    --tw-gradient-from-position: ;
-    --tw-gradient-via-position: ;
-    --tw-gradient-to-position: ;
-    --tw-ordinal: ;
-    --tw-slashed-zero: ;
-    --tw-numeric-figure: ;
-    --tw-numeric-spacing: ;
-    --tw-numeric-fraction: ;
-    --tw-ring-inset: ;
-    --tw-ring-offset-width: 0px;
-    --tw-ring-offset-color: #fff;
-    --tw-ring-color: #3b82f680;
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-    --tw-shadow: 0 0 #0000;
-    --tw-shadow-colored: 0 0 #0000;
-    --tw-blur: ;
-    --tw-brightness: ;
-    --tw-contrast: ;
-    --tw-grayscale: ;
-    --tw-hue-rotate: ;
-    --tw-invert: ;
-    --tw-saturate: ;
-    --tw-sepia: ;
-    --tw-drop-shadow: ;
-    --tw-backdrop-blur: ;
-    --tw-backdrop-brightness: ;
-    --tw-backdrop-contrast: ;
-    --tw-backdrop-grayscale: ;
-    --tw-backdrop-hue-rotate: ;
-    --tw-backdrop-invert: ;
-    --tw-backdrop-opacity: ;
-    --tw-backdrop-saturate: ;
-    --tw-backdrop-sepia: ;
   }
 
   /* #endregion */


### PR DESCRIPTION
Fixes #66.

## Summary
- Selectors for Tailwind's `--tw-*` custom-property reset were nested under `.slack_blocks_to_jsx.styles_enabled`, while the utility classes themselves are scoped to `#slack_blocks_to_jsx` (via `tailwind.config.js`'s `important: "#slack_blocks_to_jsx"`). Because the reset and the utilities lived in different scopes, the variables could stay unset and the resulting `transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) …` declaration was invalid — browsers silently dropped it. Most visibly, select-dropdown chevrons (which rely on `-translate-y-1/2`) rendered near the top of the field instead of vertically centered.
- Move the `--tw-*` reset out to the same `#slack_blocks_to_jsx` scope as the generated utilities so the variables are always initialized for any element a transform/filter/ring/etc. utility might land on. This is option (1) from the issue's "Suggested fix" section — the smaller, safer fix.

## Before / after (compiled `dist/style.css`)

Before:

```css
.slack_blocks_to_jsx.styles_enabled *,
.slack_blocks_to_jsx.styles_enabled ::backdrop,
.slack_blocks_to_jsx.styles_enabled :after,
.slack_blocks_to_jsx.styles_enabled :before { --tw-translate-x: 0; … }
```

After:

```css
#slack_blocks_to_jsx,
#slack_blocks_to_jsx *,
#slack_blocks_to_jsx ::backdrop,
#slack_blocks_to_jsx :after,
#slack_blocks_to_jsx :before { --tw-translate-x: 0; … }
```

## Test plan
- [x] `pnpm run lint` (tsc) — passes.
- [x] `pnpm run build:css` — passes; verified the compiled `dist/style.css` now scopes the `--tw-*` reset to `#slack_blocks_to_jsx` instead of `.slack_blocks_to_jsx.styles_enabled`.
- [ ] Visual check in the playground: render any element that uses `-translate-y-1/2` (e.g., `static_select`, `multi_static_select`, `users_select`, `email_input`, `number_input`, `date_picker`, `time_picker`, `url_input`) and confirm the chevron / left-icon is vertically centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)