### PR TITLE
fix: add left/right navigation buttons to carousel block

### DIFF
--- a/src/components/blocks/carousel.tsx
+++ b/src/components/blocks/carousel.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CarouselBlock } from "../../types";
 import { Card } from "./card";
 
@@ -9,16 +10,53 @@ export const Carousel = (props: CarouselProps) => {
   const { elements, block_id } = props.data;
   const cards = elements.slice(0, 10);
 
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollButtons = useCallback(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    const tolerance = 8;
+    setCanScrollLeft(scrollLeft > tolerance);
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - tolerance);
+  }, []);
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    updateScrollButtons();
+    el.addEventListener("scroll", updateScrollButtons, { passive: true });
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateScrollButtons) : null;
+    resizeObserver?.observe(el);
+    window.addEventListener("resize", updateScrollButtons);
+    return () => {
+      el.removeEventListener("scroll", updateScrollButtons);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateScrollButtons);
+    };
+  }, [updateScrollButtons, cards.length]);
+
+  const scrollBy = (direction: "left" | "right") => {
+    const el = trackRef.current;
+    if (!el) return;
+    const delta = el.clientWidth * 0.8 * (direction === "left" ? -1 : 1);
+    el.scrollBy({ left: delta, behavior: "smooth" });
+  };
+
   if (cards.length === 0) return null;
 
   return (
     <div
       id={block_id}
-      className="my-2 slack_blocks_to_jsx__carousel"
+      className="my-2 relative slack_blocks_to_jsx__carousel"
       role="region"
       aria-label="Carousel"
     >
       <div
+        ref={trackRef}
         className="flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 -mx-1 px-1 slack_blocks_to_jsx__carousel_track"
         style={{ scrollbarWidth: "thin" }}
       >
@@ -26,6 +64,52 @@ export const Carousel = (props: CarouselProps) => {
           <Card key={card.block_id || i} data={card} inCarousel />
         ))}
       </div>
+
+      {canScrollLeft && (
+        <button
+          type="button"
+          aria-label="Scroll left"
+          onClick={() => scrollBy("left")}
+          className="absolute left-1 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full flex items-center justify-center bg-white-primary dark:bg-dark-bg-secondary text-black-primary dark:text-dark-text-primary border border-black-primary/[0.13] dark:border-dark-border shadow-md hover:bg-gray-secondary dark:hover:bg-dark-bg-primary slack_blocks_to_jsx__carousel_arrow slack_blocks_to_jsx__carousel_arrow--left"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            aria-hidden="true"
+            className="w-5 h-5"
+          >
+            <path
+              fill="currentColor"
+              fillRule="evenodd"
+              d="M12.03 5.72a.75.75 0 0 1 0 1.06L8.81 10l3.22 3.22a.75.75 0 1 1-1.06 1.06l-3.75-3.75a.75.75 0 0 1 0-1.06l3.75-3.75a.75.75 0 0 1 1.06 0"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      )}
+
+      {canScrollRight && (
+        <button
+          type="button"
+          aria-label="Scroll right"
+          onClick={() => scrollBy("right")}
+          className="absolute right-1 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full flex items-center justify-center bg-white-primary dark:bg-dark-bg-secondary text-black-primary dark:text-dark-text-primary border border-black-primary/[0.13] dark:border-dark-border shadow-md hover:bg-gray-secondary dark:hover:bg-dark-bg-primary slack_blocks_to_jsx__carousel_arrow slack_blocks_to_jsx__carousel_arrow--right"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            aria-hidden="true"
+            className="w-5 h-5"
+          >
+            <path
+              fill="currentColor"
+              fillRule="evenodd"
+              d="M7.72 5.72a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1 0 1.06l-3.75 3.75a.75.75 0 0 1-1.06-1.06L10.94 10 7.72 6.78a.75.75 0 0 1 0-1.06"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes [#65](https://github.com/themashcodee/slack-blocks-to-jsx/issues/65). The `carousel` block previously rendered as a horizontal scroll row with no navigation controls, while Slack's official Block Kit renderer overlays chevron buttons on the left/right edges of the row.

- Adds left/right chevron buttons overlaid on the carousel, matching Slack's `caret-left` / `caret-right` icon paths
- Buttons appear/disappear dynamically based on scroll position (left hides at the start, right hides at the end), using a `scroll` listener plus a `ResizeObserver` so resizing the container updates visibility
- Clicking scrolls the track by ~80% of its visible width using `scrollBy({ behavior: "smooth" })`, which naturally lands on the next snap point thanks to the existing `snap-mandatory`
- 8px tolerance on scroll-position checks so the existing `px-1` track padding doesn't cause the left arrow to flash on load

## Test plan

- [x] `pnpm lint` (tsc) passes
- [x] `pnpm build` produces clean ESM + CJS + d.ts output
- [x] Playground renders the carousel with only the right chevron visible at initial scroll position, both chevrons after scrolling, and only the left chevron at the end
- [ ] Manual verification in a real browser that smooth-scroll + snap behave correctly (the headless preview I used did not support programmatic scrolling, but `scrollBy` is a standard browser API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)