### PR TITLE
chore: pin Dependabot weekly schedule to Saturday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 10
     groups:
       dev-dependencies:
@@ -21,6 +22,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: saturday
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Adds `day: saturday` to both the npm and github-actions update blocks in `.github/dependabot.yml`. Previously the `weekly` interval had no explicit day and defaulted to Monday; now the weekly run is pinned to Saturday. No other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)