### PR TITLE
ci: auto-comment new PRs with a live playground test link

### DIFF
--- a/.github/workflows/playground-comment.yml
+++ b/.github/workflows/playground-comment.yml
@@ -1,0 +1,46 @@
+name: Playground Comment
+
+# Greets every new PR with a one-click way to test the changes live: the pkg.pr.new
+# preview build (published by preview.yml) loaded into the hosted playground — no install,
+# no release needed.
+#
+# Uses `pull_request_target` so it can comment on PRs from forks too (the default
+# `pull_request` token is read-only for fork PRs). This is safe here because the job NEVER
+# checks out or runs PR code — it only posts a static comment via the GitHub API.
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Skip bot-authored PRs (e.g. dependabot) — the playground note isn't useful there.
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.issue.number;
+            const author = context.payload.pull_request.user.login;
+            const build = `https://pkg.pr.new/slack-blocks-to-jsx@${pr}`;
+            const body = [
+              `👋 Thanks for the PR, @${author}!`,
+              ``,
+              `You can try these changes **live, before any release** — no install needed.`,
+              `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground and load this PR's build:`,
+              ``,
+              `🛝 **Playground:** https://slack-block-to-jsx-playground.vercel.app/`,
+              `📦 **This PR's build:** \`${build}\``,
+              ``,
+              `Paste the build URL into the **Library package** field (or hit the **pkg.pr #${pr}** preset) and click **Load build** — your blocks render against this exact PR. 🎉`,
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });


### PR DESCRIPTION
## What

Adds `.github/workflows/playground-comment.yml` — a workflow that posts a comment on **every newly opened PR** pointing the author to the hosted playground, pre-named with this PR's `pkg.pr.new` build. Contributors can then test their changes **live, before any release**, with no local setup.

This builds on the existing `preview.yml` (which already publishes a per-PR build to `pkg.pr.new`) — this PR just closes the loop by telling authors how to load that build into the playground.

## How it works

- Triggers on `pull_request_target` with `types: [opened]` → fires once per new PR (no duplicate comments on subsequent pushes).
- Posts a comment via `actions/github-script` containing:
  - 🛝 the playground URL: https://slack-block-to-jsx-playground.vercel.app/
  - 📦 this PR's build: `https://pkg.pr.new/slack-blocks-to-jsx@<pr#>`
  - short instructions (paste into **Library package** / hit the **pkg.pr #<pr#>** preset → **Load build**).
- Skips bot-authored PRs (e.g. dependabot).

## Why `pull_request_target`

External PRs come from forks, and the default `pull_request` token is **read-only** on forks — so the comment would 403. `pull_request_target` runs with a writable token in the base-repo context. This is the **safe** use of it: the job never checks out or runs PR code, it only calls the comment API. It also auto-runs for first-time contributors (no manual approval gate).

Uses only the built-in `GITHUB_TOKEN` (`permissions: pull-requests: write`) — no secrets to configure.

## Note

Because `pull_request_target` workflows run from the version on `main`, this only takes effect **after merge**, on PRs opened thereafter (it won't retroactively comment on currently-open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)