### PR TITLE
feat: support the new Slack container block

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ const blocks: Block[] = [
 | Alert              | ✅ Full | Status banner with info / warning / error / success levels   |
 | Card               | ✅ Full | Title, subtitle, body, image, icon, and action buttons       |
 | Carousel           | ✅ Full | Horizontally-scrollable gallery of up to 10 cards            |
+| Container          | ✅ Full | Groups child blocks; title, icon, `width`, collapse/expand   |
 | Plan               | ✅ Full | Sequential task display with status indicators               |
 | Task Card          | ✅ Full | Individual task with title, details, output, sources, status |
 | Data Visualization | ✅ Full | Line, bar, area, and pie charts; legend, axes, table & CSV   |

--- a/src/components/blocks/container.tsx
+++ b/src/components/blocks/container.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { ContainerBlock } from "../../types";
+import { TextObject } from "../composition_objects";
+import { getBlockComponent } from "../index";
+import { merge_classes } from "../../utils";
+
+type ContainerProps = {
+  data: ContainerBlock;
+};
+
+const WIDTH_CLASSES: Record<NonNullable<ContainerBlock["width"]>, string> = {
+  narrow: "max-w-[320px]",
+  standard: "max-w-[440px]",
+  wide: "max-w-[520px]",
+  full: "w-full",
+};
+
+export const Container = (props: ContainerProps) => {
+  const {
+    title,
+    subtitle,
+    icon,
+    child_blocks,
+    width = "standard",
+    is_collapsible = false,
+    default_collapsed = false,
+    block_id,
+  } = props.data;
+
+  const [expanded, setExpanded] = useState(!(is_collapsible && default_collapsed));
+  const collapsed = is_collapsible && !expanded;
+
+  const header = (
+    <>
+      {icon?.image_url && (
+        <span className="shrink-0 slack_blocks_to_jsx__container_icon">
+          <img
+            src={icon.image_url}
+            alt={icon.alt_text || ""}
+            className="w-5 h-5 rounded object-cover"
+          />
+        </span>
+      )}
+
+      <span className="flex flex-col min-w-0 flex-1 slack_blocks_to_jsx__container_title_group">
+        {title && (
+          <span className="font-bold text-black-primary dark:text-dark-text-primary truncate slack_blocks_to_jsx__container_title">
+            <TextObject data={title} />
+          </span>
+        )}
+        {subtitle && (
+          <span className="text-small text-black-secondary dark:text-dark-text-secondary truncate slack_blocks_to_jsx__container_subtitle">
+            <TextObject data={subtitle} />
+          </span>
+        )}
+      </span>
+
+      {is_collapsible && (
+        <span
+          aria-hidden="true"
+          className={merge_classes([
+            "shrink-0 transition-transform slack_blocks_to_jsx__container_caret",
+            collapsed ? "-rotate-90" : "",
+          ])}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" className="w-4 h-4">
+            <path
+              fill="currentColor"
+              fillRule="evenodd"
+              d="M5.72 7.47a.75.75 0 0 1 1.06 0L10 10.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L5.72 8.53a.75.75 0 0 1 0-1.06"
+              clipRule="evenodd"
+            />
+          </svg>
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      id={block_id}
+      role="group"
+      aria-label={title?.text}
+      className={merge_classes([
+        "my-2 rounded-lg border border-black-primary/[0.13] dark:border-dark-border bg-white-primary dark:bg-dark-bg-secondary overflow-hidden slack_blocks_to_jsx__container",
+        WIDTH_CLASSES[width],
+      ])}
+    >
+      {is_collapsible ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((prev) => !prev)}
+          className="w-full flex items-center gap-2 p-3 text-left slack_blocks_to_jsx__container_header"
+        >
+          {header}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 p-3 slack_blocks_to_jsx__container_header">
+          {header}
+        </div>
+      )}
+
+      {!collapsed && (
+        <div className="px-3 pb-3 slack_blocks_to_jsx--blocks slack_blocks_to_jsx__container_content">
+          {child_blocks.map((child, i) => {
+            const element = getBlockComponent(child);
+            if (!element) return null;
+            return <div key={child.block_id || i}>{element}</div>;
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/blocks/index.ts
+++ b/src/components/blocks/index.ts
@@ -2,6 +2,7 @@ export * from "./actions";
 export * from "./alert";
 export * from "./card";
 export * from "./carousel";
+export * from "./container";
 export * from "./context";
 export * from "./context_actions";
 export * from "./data_visualization";

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -6,6 +6,7 @@ import {
   Alert,
   Card,
   Carousel,
+  Container,
   Context,
   ContextActions,
   DataVisualization,
@@ -72,6 +73,7 @@ export const getBlockComponent = (block: Block): ReactNode => {
   if (block.type === "alert") return <Alert data={block} />;
   if (block.type === "card") return <Card data={block} />;
   if (block.type === "carousel") return <Carousel data={block} />;
+  if (block.type === "container") return <Container data={block} />;
   if (block.type === "data_visualization") return <DataVisualization data={block} />;
 
   return null;

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -34,6 +34,7 @@ export type Block =
   | AlertBlock
   | CardBlock
   | CarouselBlock
+  | ContainerBlock
   | ContextBlock
   | ContextActionsBlock
   | DataVisualizationBlock
@@ -572,6 +573,60 @@ export type CarouselBlock = {
    * An array of {@link CardBlock} entries. Minimum 1, maximum 10.
    */
   elements: CardBlock[];
+  /**
+   * A string acting as a unique identifier for a block. If not specified, one will be generated.
+   * Maximum length for this field is 255 characters.
+   */
+  block_id?: string;
+};
+
+export type ContainerBlock = {
+  /**
+   * Available in surfaces: **Messages**
+   *
+   * * Docs: {@link https://docs.slack.dev/reference/block-kit/blocks/container-block View here}
+   * * Changelog: {@link https://docs.slack.dev/changelog/2026/06/29/block-kit-container-block View here}
+   *
+   * A ***container*** block is a general-purpose wrapper that groups child blocks together
+   * with an optional title, subtitle and icon, a configurable ***width***, and optional
+   * collapse/expand behavior.
+   */
+  type: "container";
+  /**
+   * A plain-text title for the container, in the form of a {@link TextObject} of type
+   * ***plain_text***. Maximum length is 150 characters.
+   *
+   * Note: Slack's reference docs type this (and ***subtitle***) as a string, but the API
+   * actually expects a ***plain_text*** text object.
+   */
+  title: TextObject<"plain_text">;
+  /**
+   * An optional subtitle rendered below the title in a smaller, muted style. A
+   * {@link TextObject} of type ***plain_text*** or ***mrkdwn***. Maximum length is 150 characters.
+   */
+  subtitle?: TextObject;
+  /**
+   * An optional icon ({@link ImageElement}) rendered next to the title.
+   */
+  icon?: ImageElement;
+  /**
+   * The child blocks rendered inside the container. Maximum of 10 blocks.
+   */
+  child_blocks: Block[];
+  /**
+   * Controls the rendered width of the container. Defaults to ***standard***.
+   */
+  width?: "narrow" | "standard" | "wide" | "full";
+  /**
+   * When true, the container renders a clickable header that collapses and expands its
+   * content. Defaults to ***false***.
+   */
+  is_collapsible?: boolean;
+  /**
+   * When ***is_collapsible*** is true, controls whether the container starts collapsed.
+   * Defaults to ***false***.
+   */
+  default_collapsed?: boolean;
   /**
    * A string acting as a unique identifier for a block. If not specified, one will be generated.
    * Maximum length for this field is 255 characters.

--- a/src/utils/sanitize_for_slack.ts
+++ b/src/utils/sanitize_for_slack.ts
@@ -37,6 +37,14 @@ const sanitizeBlock = (block: Block): unknown => {
     };
   }
 
+  // Recursively sanitize the child blocks of a container block
+  if (block.type === "container") {
+    return {
+      ...block,
+      child_blocks: block.child_blocks.map(sanitizeBlock),
+    };
+  }
+
   // Sanitize element in input blocks
   if (block.type === "input") {
     return {

--- a/test/container.test.mjs
+++ b/test/container.test.mjs
@@ -1,0 +1,77 @@
+// The `container` block groups child blocks together with an optional title, subtitle,
+// icon, configurable width, and optional collapse/expand behavior. These tests render the
+// JSON fixtures from the Block Kit examples and lock in the accessible group label, the
+// header (button vs static div depending on `is_collapsible`), the initial collapsed state
+// (SSR reflects `default_collapsed`), and that child blocks render through the normal block
+// dispatcher. Run against the built dist/ via Node's built-in runner (CI builds first).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { Message } from "../dist/index.mjs";
+
+const render = (blocks) =>
+  ReactDOMServer.renderToStaticMarkup(
+    React.createElement(Message, {
+      logo: "logo.png",
+      name: "Tester",
+      theme: "light",
+      blocks,
+    }),
+  );
+
+const child = (text) => ({ type: "section", text: { type: "mrkdwn", text } });
+
+const collapsible = {
+  type: "container",
+  block_id: "bkb_collapsible",
+  title: { type: "plain_text", text: "Bulk update: 2 records selected" },
+  subtitle: { type: "plain_text", text: "Review changes before confirming" },
+  is_collapsible: true,
+  child_blocks: [child("DCW-1024"), { type: "divider" }, child("DCW-1025")],
+};
+
+const nonCollapsible = {
+  type: "container",
+  block_id: "no-collapse",
+  title: { type: "plain_text", text: "Static container" },
+  is_collapsible: false,
+  child_blocks: [child("always visible")],
+};
+
+const defaultCollapsed = {
+  type: "container",
+  block_id: "default-collapsed",
+  title: { type: "plain_text", text: "Collapsed by default" },
+  icon: { type: "image", alt_text: "icon", image_url: "https://example.com/icon.png" },
+  is_collapsible: true,
+  default_collapsed: true,
+  child_blocks: [child("hidden until expanded")],
+};
+
+test("collapsible: group label, expandable button header, and child blocks render", () => {
+  const out = render([collapsible]);
+  assert.match(out, /role="group" aria-label="Bulk update: 2 records selected"/);
+  // collapsible header is a <button> that starts expanded
+  assert.match(out, /<button[^>]*aria-expanded="true"/);
+  assert.match(out, /Review changes before confirming/);
+  // child blocks render through the normal dispatcher
+  assert.match(out, /DCW-1024/);
+  assert.match(out, /DCW-1025/);
+  assert.match(out, /id="bkb_collapsible"/);
+});
+
+test("non-collapsible: header is a static div (no button / aria-expanded), content shown", () => {
+  const out = render([nonCollapsible]);
+  assert.doesNotMatch(out, /aria-expanded/);
+  assert.doesNotMatch(out, /<button/);
+  assert.match(out, /always visible/);
+});
+
+test("default_collapsed: starts collapsed so child content is not rendered, icon shows", () => {
+  const out = render([defaultCollapsed]);
+  assert.match(out, /<button[^>]*aria-expanded="false"/);
+  assert.doesNotMatch(out, /hidden until expanded/);
+  assert.match(out, /<img[^>]*src="https:\/\/example.com\/icon.png"/);
+});


### PR DESCRIPTION
## What

Adds support for Slack's new Block Kit **container** block ([2026-06-29 changelog](https://docs.slack.dev/changelog/2026/06/29/block-kit-container-block)) — a general-purpose wrapper that groups child blocks together with an optional title, subtitle, and icon, a configurable width, and optional collapse/expand behavior.

## Changes

- **Type** — new `ContainerBlock` in `src/types/layout.ts`, added to the `Block` union. `title`/`subtitle` are `plain_text` text objects (the Slack reference docs incorrectly type these as strings — the API expects text objects, per the parent issue's finding). `width` is `narrow | standard | wide | full` (the ticket's "configurable size").
- **Component** — `src/components/blocks/container.tsx`: `role="group"` wrapper, title/subtitle/icon header, width-based max-width, and SSR-safe client-side collapse/expand (initial state reflects `default_collapsed`). Children render through the existing `getBlockComponent` dispatcher.
- **Wiring** — registered in `components/index.tsx`, exported from `blocks/index.ts`.
- **Sanitize** — recursive `child_blocks` handling in `sanitize_for_slack.ts` so the "Open in Block Kit Builder" debug link stays valid.
- **Docs + tests** — Supported Blocks readme row; `test/container.test.mjs` (collapsible, non-collapsible, default-collapsed).

## Notes for reviewers

- The ticket's docs link pointed at *image-element* by mistake; schema confirmed against the real [container-block reference](https://docs.slack.dev/reference/block-kit/blocks/container-block). The "size" is Slack's `width` field.
- "Update npm versions from sibling tickets" is N/A here — this repo doesn't depend on `slack-web-api-client` or `slack-block-kit-validator`.
- Deliberate simplifications: no animated collapse-height transition (just show/hide), and `width` pixel breakpoints are estimates — tune if they don't match Slack's actual rendering.

Typecheck (`tsc`), build, and all tests pass.
