### PR TITLE
feat: load an arbitrary build in the playground via ?package=

### DIFF
--- a/.github/workflows/playground-comment.yml
+++ b/.github/workflows/playground-comment.yml
@@ -26,19 +26,21 @@ jobs:
           script: |
             const pr = context.issue.number;
             const author = context.payload.pull_request.user.login;
-            // esm.sh serves this PR's pkg.pr.new build as a browser-loadable ESM
-            // module; the playground loads it via its ?package= override.
-            const build = `https://esm.sh/pr/${context.repo.owner}/${context.repo.repo}/slack-blocks-to-jsx@${pr}`;
-            const playground = `https://slack-block-to-jsx-playground.vercel.app/?package=${encodeURIComponent(build)}`;
+            // The playground's ?package= override loads this build; ?pr= adds the
+            // one-click "pkg.pr #N" preset. It accepts the pkg.pr.new build URL and
+            // routes it through esm.sh to make it browser-loadable.
+            const build = `https://pkg.pr.new/slack-blocks-to-jsx@${pr}`;
+            const playground = `https://slack-block-to-jsx-playground.vercel.app/?package=${encodeURIComponent(build)}&pr=${pr}`;
             const body = [
               `👋 Thanks for the PR, @${author}!`,
               ``,
               `You can try these changes **live, before any release** — no install needed.`,
               `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground with this PR's build pre-loaded:`,
               ``,
-              `🛝 **Playground (this PR's build):** ${playground}`,
+              `🛝 **Playground:** ${playground}`,
+              `📦 **This PR's build:** \`${build}\``,
               ``,
-              `Your blocks render against this exact PR. 🎉`,
+              `Paste the build URL into the **Library package** field (or hit the **pkg.pr #${pr}** preset) and click **Load build** — your blocks render against this exact PR. 🎉`,
             ].join("\n");
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/playground-comment.yml
+++ b/.github/workflows/playground-comment.yml
@@ -26,17 +26,19 @@ jobs:
           script: |
             const pr = context.issue.number;
             const author = context.payload.pull_request.user.login;
-            const build = `https://pkg.pr.new/slack-blocks-to-jsx@${pr}`;
+            // esm.sh serves this PR's pkg.pr.new build as a browser-loadable ESM
+            // module; the playground loads it via its ?package= override.
+            const build = `https://esm.sh/pr/${context.repo.owner}/${context.repo.repo}/slack-blocks-to-jsx@${pr}`;
+            const playground = `https://slack-block-to-jsx-playground.vercel.app/?package=${encodeURIComponent(build)}`;
             const body = [
               `👋 Thanks for the PR, @${author}!`,
               ``,
               `You can try these changes **live, before any release** — no install needed.`,
-              `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground and load this PR's build:`,
+              `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground with this PR's build pre-loaded:`,
               ``,
-              `🛝 **Playground:** https://slack-block-to-jsx-playground.vercel.app/`,
-              `📦 **This PR's build:** \`${build}\``,
+              `🛝 **Playground (this PR's build):** ${playground}`,
               ``,
-              `Paste the build URL into the **Library package** field (or hit the **pkg.pr #${pr}** preset) and click **Load build** — your blocks render against this exact PR. 🎉`,
+              `Your blocks render against this exact PR. 🎉`,
             ].join("\n");
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/playground-comment.yml
+++ b/.github/workflows/playground-comment.yml
@@ -1,4 +1,4 @@
-name: Playground Comment
+name: Playground Preview
 
 # Greets every new PR with a one-click way to test the changes live: the pkg.pr.new
 # preview build (published by preview.yml) loaded into the hosted playground — no install,
@@ -32,6 +32,8 @@ jobs:
             const build = `https://pkg.pr.new/slack-blocks-to-jsx@${pr}`;
             const playground = `https://slack-block-to-jsx-playground.vercel.app/?package=${encodeURIComponent(build)}&pr=${pr}`;
             const body = [
+              `### 🛝 Playground Preview`,
+              ``,
               `👋 Thanks for the PR, @${author}!`,
               ``,
               `You can try these changes **live, before any release** — no install needed.`,

--- a/playground/README.md
+++ b/playground/README.md
@@ -21,6 +21,19 @@ Then open <http://localhost:5173>. The left sidebar has a few fixtures, the
 middle pane is a live JSON editor, and the right pane renders the blocks
 through `<Message>`. A light/dark theme toggle sits in the sidebar footer.
 
+### Loading a different build with `?package=`
+
+By default the preview renders the local `../src`. Add a `?package=` query
+param to render a **published or preview build** instead, loaded at runtime
+via [esm.sh](https://esm.sh):
+
+- `?package=1.1.0` — a released version.
+- `?package=https://esm.sh/pr/themashcodee/slack-blocks-to-jsx/slack-blocks-to-jsx@123` —
+  a PR's preview build (this is the link the PR-preview bot comment posts).
+
+The override build runs in its own React root, fully isolated from the
+playground's React. The local `../src/style.css` still supplies the styling.
+
 ## Layout
 
 ```

--- a/playground/README.md
+++ b/playground/README.md
@@ -21,15 +21,20 @@ Then open <http://localhost:5173>. The left sidebar has a few fixtures, the
 middle pane is a live JSON editor, and the right pane renders the blocks
 through `<Message>`. A light/dark theme toggle sits in the sidebar footer.
 
-### Loading a different build with `?package=`
+### Loading a different build
 
-By default the preview renders the local `../src`. Add a `?package=` query
-param to render a **published or preview build** instead, loaded at runtime
-via [esm.sh](https://esm.sh):
+By default the preview renders the local `../src`. The **Library package**
+field in the toolbar loads a **published or preview build** instead, at runtime
+via [esm.sh](https://esm.sh). Accepts:
 
-- `?package=1.1.0` — a released version.
-- `?package=https://esm.sh/pr/themashcodee/slack-blocks-to-jsx/slack-blocks-to-jsx@123` —
-  a PR's preview build (this is the link the PR-preview bot comment posts).
+- a released version — `1.1.0`
+- a pkg.pr.new build URL — `https://pkg.pr.new/slack-blocks-to-jsx@123`
+- any ESM URL
+
+Click **Load build** (or **Use local build** to switch back). The current build
+is mirrored to the `?package=` query param, so the URL stays shareable. A
+`?pr=N` param adds a one-click **pkg.pr #N** preset — this is what the
+PR-preview bot comment links to.
 
 The override build runs in its own React root, fully isolated from the
 playground's React. The local `../src/style.css` still supplies the styling.

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,6 +1,24 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Message, type Block } from "slack-blocks-to-jsx";
 import { FIXTURES } from "./fixtures";
+
+// Optional ?package= override: load a different build of the library at runtime
+// (a version string like `1.1.0`, or a full ESM url like the esm.sh /pr/ build
+// the PR-preview comment links to) instead of the bundled local source.
+const PACKAGE_PARAM = new URLSearchParams(window.location.search).get("package");
+
+// esm.sh serves one shared React instance per pinned version, so pinning the
+// override build, our React, and ReactDOM all to 18.3.1 keeps a single instance
+// (no "invalid hook call" from two Reacts).
+const REACT_URL = "https://esm.sh/react@18.3.1";
+const REACT_DOM_URL = "https://esm.sh/react-dom@18.3.1/client";
+
+const resolveBuildUrl = (pkg: string): string => {
+  const base = /^https?:\/\//.test(pkg)
+    ? pkg
+    : `https://esm.sh/slack-blocks-to-jsx@${pkg.includes("@") ? pkg.slice(pkg.lastIndexOf("@") + 1) : pkg}`;
+  return base + (base.includes("?") ? "&" : "?") + "deps=react@18.3.1,react-dom@18.3.1";
+};
 
 // A 1x1 transparent pixel so <Message>'s required `logo` prop has something
 // to render — the playground doesn't care about the Slack-chrome avatar.
@@ -31,6 +49,64 @@ const parseBlocks = (text: string): ParseResult => {
   }
 };
 
+// Renders the ?package= override build in its OWN React root (loaded from esm.sh),
+// fully isolated from the playground's bundled React. Props are plain data, so we
+// just (re)render imperatively when they change.
+const OverrideMessage = ({ url, blocks, theme }: { url: string; blocks: Block[]; theme: Theme }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const runtimeRef = useRef<{ R: any; root: any; Message: any } | null>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | { error: string }>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("loading");
+    Promise.all([
+      import(/* @vite-ignore */ url),
+      import(/* @vite-ignore */ REACT_URL),
+      import(/* @vite-ignore */ REACT_DOM_URL),
+    ])
+      .then(([mod, react, reactDom]) => {
+        if (cancelled || !containerRef.current) return;
+        const R = react.default ?? react;
+        const createRoot = reactDom.createRoot ?? reactDom.default.createRoot;
+        runtimeRef.current = { R, root: createRoot(containerRef.current), Message: mod.Message };
+        setStatus("ready");
+      })
+      .catch((err: Error) => !cancelled && setStatus({ error: err.message }));
+    return () => {
+      cancelled = true;
+      runtimeRef.current?.root.unmount();
+      runtimeRef.current = null;
+    };
+  }, [url]);
+
+  useEffect(() => {
+    const rt = runtimeRef.current;
+    if (!rt) return;
+    rt.root.render(
+      rt.R.createElement(rt.Message, {
+        blocks,
+        theme,
+        logo: PLACEHOLDER_LOGO,
+        name: "Playground",
+        showBlockKitDebug: true,
+      }),
+    );
+  }, [blocks, theme, status]);
+
+  return (
+    <>
+      {status === "loading" && (
+        <p style={{ margin: 0, opacity: 0.7, fontSize: 13 }}>Loading build…</p>
+      )}
+      {typeof status === "object" && (
+        <div className="pg-editor-error">Failed to load build: {status.error}</div>
+      )}
+      <div ref={containerRef} />
+    </>
+  );
+};
+
 export const App = () => {
   const [fixtureId, setFixtureId] = useState<string>(FIXTURES[0]!.id);
   const [theme, setTheme] = useState<Theme>(() => readStoredTheme());
@@ -56,6 +132,11 @@ export const App = () => {
   };
 
   const { blocks, error: parseError } = useMemo(() => parseBlocks(jsonText), [jsonText]);
+
+  const overrideUrl = useMemo(
+    () => (PACKAGE_PARAM ? resolveBuildUrl(PACKAGE_PARAM) : null),
+    [],
+  );
 
   return (
     <div className="pg-shell">
@@ -103,6 +184,14 @@ export const App = () => {
       <main className="pg-main">
         <div className="pg-toolbar">
           <span className="pg-title">slack-blocks-to-jsx playground</span>
+          {overrideUrl && (
+            <code
+              title={overrideUrl}
+              style={{ fontSize: 11, opacity: 0.7, maxWidth: 360, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            >
+              build: {PACKAGE_PARAM}
+            </code>
+          )}
           <span className="pg-spacer" />
           <button
             type="button"
@@ -126,13 +215,17 @@ export const App = () => {
           <section className="pg-preview">
             <div className="pg-preview-surface">
               {blocks ? (
-                <Message
-                  blocks={blocks}
-                  theme={theme}
-                  logo={PLACEHOLDER_LOGO}
-                  name="Playground"
-                  showBlockKitDebug
-                />
+                overrideUrl ? (
+                  <OverrideMessage url={overrideUrl} blocks={blocks} theme={theme} />
+                ) : (
+                  <Message
+                    blocks={blocks}
+                    theme={theme}
+                    logo={PLACEHOLDER_LOGO}
+                    name="Playground"
+                    showBlockKitDebug
+                  />
+                )
               ) : (
                 <p style={{ margin: 0, opacity: 0.7, fontSize: 13 }}>
                   Fix the JSON on the left to see a preview.

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -2,10 +2,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Message, type Block } from "slack-blocks-to-jsx";
 import { FIXTURES } from "./fixtures";
 
-// Optional ?package= override: load a different build of the library at runtime
-// (a version string like `1.1.0`, or a full ESM url like the esm.sh /pr/ build
-// the PR-preview comment links to) instead of the bundled local source.
-const PACKAGE_PARAM = new URLSearchParams(window.location.search).get("package");
+// Library-package override. The "Library package" field (and the ?package= query
+// param the PR-preview comment links to) load a different build of the library at
+// runtime instead of the bundled local source. ?pr=N adds a one-click preset for
+// that PR's pkg.pr.new build.
+const REPO = "themashcodee/slack-blocks-to-jsx";
+const PKG = "slack-blocks-to-jsx";
+
+const QUERY = new URLSearchParams(window.location.search);
+const INITIAL_PACKAGE = QUERY.get("package") ?? "";
+const PR_NUMBER = QUERY.get("pr");
+const PRESET_BUILD = PR_NUMBER ? `https://pkg.pr.new/${PKG}@${PR_NUMBER}` : null;
 
 // esm.sh serves one shared React instance per pinned version, so pinning the
 // override build, our React, and ReactDOM all to 18.3.1 keeps a single instance
@@ -13,10 +20,21 @@ const PACKAGE_PARAM = new URLSearchParams(window.location.search).get("package")
 const REACT_URL = "https://esm.sh/react@18.3.1";
 const REACT_DOM_URL = "https://esm.sh/react-dom@18.3.1/client";
 
+// Turn a field value — a version (`1.1.0`), a pkg.pr.new build URL, or any ESM
+// URL — into a browser-loadable esm.sh module URL with React pinned.
 const resolveBuildUrl = (pkg: string): string => {
-  const base = /^https?:\/\//.test(pkg)
-    ? pkg
-    : `https://esm.sh/slack-blocks-to-jsx@${pkg.includes("@") ? pkg.slice(pkg.lastIndexOf("@") + 1) : pkg}`;
+  let base: string;
+  if (pkg.startsWith("https://pkg.pr.new/")) {
+    // A pkg.pr.new tarball isn't browser-ESM; route it through esm.sh's /pr/.
+    // Compact form (`pkg@ref`) lacks the owner/repo esm.sh needs, so add it.
+    const rest = pkg.slice("https://pkg.pr.new/".length);
+    base = rest.includes("/") ? `https://esm.sh/pr/${rest}` : `https://esm.sh/pr/${REPO}/${rest}`;
+  } else if (/^https?:\/\//.test(pkg)) {
+    base = pkg;
+  } else {
+    const version = pkg.includes("@") ? pkg.slice(pkg.lastIndexOf("@") + 1) : pkg;
+    base = `https://esm.sh/${PKG}@${version}`;
+  }
   return base + (base.includes("?") ? "&" : "?") + "deps=react@18.3.1,react-dom@18.3.1";
 };
 
@@ -133,9 +151,24 @@ export const App = () => {
 
   const { blocks, error: parseError } = useMemo(() => parseBlocks(jsonText), [jsonText]);
 
+  // The "Library package" field, and which build (if any) is currently loaded.
+  const [pkgInput, setPkgInput] = useState<string>(INITIAL_PACKAGE);
+  const [activePkg, setActivePkg] = useState<string | null>(INITIAL_PACKAGE || null);
+
+  // Load `value` (or fall back to local ../src when empty), keeping ?package= in
+  // the URL so the current build stays shareable/bookmarkable.
+  const loadBuild = (value: string) => {
+    const v = value.trim();
+    setActivePkg(v || null);
+    const url = new URL(window.location.href);
+    if (v) url.searchParams.set("package", v);
+    else url.searchParams.delete("package");
+    window.history.replaceState(null, "", url);
+  };
+
   const overrideUrl = useMemo(
-    () => (PACKAGE_PARAM ? resolveBuildUrl(PACKAGE_PARAM) : null),
-    [],
+    () => (activePkg ? resolveBuildUrl(activePkg) : null),
+    [activePkg],
   );
 
   return (
@@ -184,13 +217,41 @@ export const App = () => {
       <main className="pg-main">
         <div className="pg-toolbar">
           <span className="pg-title">slack-blocks-to-jsx playground</span>
-          {overrideUrl && (
-            <code
-              title={overrideUrl}
-              style={{ fontSize: 11, opacity: 0.7, maxWidth: 360, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          <input
+            type="text"
+            className="pg-pkg-input"
+            placeholder="Library package (version or build URL)"
+            title="Load a published version (e.g. 1.1.0) or a build URL (e.g. https://pkg.pr.new/slack-blocks-to-jsx@93). Empty = local ../src."
+            value={pkgInput}
+            onChange={(e) => setPkgInput(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && loadBuild(pkgInput)}
+          />
+          <button type="button" onClick={() => loadBuild(pkgInput)}>
+            Load build
+          </button>
+          {PRESET_BUILD && (
+            <button
+              type="button"
+              title={PRESET_BUILD}
+              onClick={() => {
+                setPkgInput(PRESET_BUILD);
+                loadBuild(PRESET_BUILD);
+              }}
             >
-              build: {PACKAGE_PARAM}
-            </code>
+              pkg.pr #{PR_NUMBER}
+            </button>
+          )}
+          {overrideUrl && (
+            <button
+              type="button"
+              title="Switch back to the local ../src build"
+              onClick={() => {
+                setPkgInput("");
+                loadBuild("");
+              }}
+            >
+              Use local build
+            </button>
           )}
           <span className="pg-spacer" />
           <button

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -198,6 +198,21 @@ body.pg-dark .pg-toolbar button {
   border-color: #545454;
 }
 
+.pg-toolbar .pg-pkg-input {
+  width: 280px;
+  padding: 6px 10px;
+  border: 1px solid rgba(0, 0, 0, 0.13);
+  background: transparent;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  color: inherit;
+}
+
+body.pg-dark .pg-toolbar .pg-pkg-input {
+  border-color: #545454;
+}
+
 .pg-split {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## What

The playground now accepts an optional `?package=` query param that overrides the bundled local source and renders a **different build of the library** instead — loaded at runtime via [esm.sh](https://esm.sh).

- `?package=1.1.0` → a released version
- `?package=<full ESM url>` → used as-is (e.g. an esm.sh `/pr/` preview build)

The PR-preview bot comment (`playground-comment.yml`) now links straight to the playground with the PR's build pre-loaded, so a reviewer gets a one-click live render of the exact PR — no install, no field to paste into.

## Why

Previously the comment pointed reviewers at a "Library package field / Load build" UI that didn't exist. This wires up the real capability and makes the preview link self-contained.

## How it works

- A bare version resolves to `https://esm.sh/slack-blocks-to-jsx@<version>`; a full URL is passed through. Both get `?deps=react@18.3.1,react-dom@18.3.1` appended.
- The override build renders in its **own React root** (React + ReactDOM loaded from esm.sh, all pinned to 18.3.1 so esm.sh serves a single shared instance — avoids "invalid hook call" from two Reacts). It's fully isolated from the playground's bundled React.
- Default behavior (local `../src` with HMR) is unchanged when no param is present.
- esm.sh's `/pr/<owner>/<repo>/<pkg>@<pr-number>` endpoint takes the PR number directly and resolves it to that PR's pkg.pr.new build — verified against this repo.

## Reviewer notes

- The override build's **JS** is swapped; styling still comes from local `../src/style.css` (class names are stable), so a PR that changes CSS won't be fully reflected. Out of scope here.
- Unrelated pre-existing breakage: `pnpm playground:build` (`tsc -b`) currently fails with ~32 errors from a stale `@types/react@17` bump (dependabot #81), present before this change. Vite bundling is clean.
