### PR TITLE
fix: repair pnpm playground:build and run it in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint && pnpm run build && pnpm test
+
+      # The playground is a separate npm project; build it too so its type-check
+      # (against the library's built types) can't silently rot. `playground:build`
+      # rebuilds the library first, so this also covers the dist it consumes.
+      - run: pnpm playground:install
+      - run: pnpm playground:build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint && pnpm run build && pnpm test
 
-      # The playground is a separate npm project; build it too so its type-check
-      # (against the library's built types) can't silently rot. `playground:build`
-      # rebuilds the library first, so this also covers the dist it consumes.
+  # Separate check: the playground is its own npm project. Type-checking it
+  # (against the library's built types) catches breakage the library's own
+  # lint/build won't. `playground:build` builds the library first for the dist
+  # it consumes, so this job is self-contained.
+  playground:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22.13
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
       - run: pnpm playground:install
       - run: pnpm playground:build

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release:alpha": "node scripts/release.mjs prerelease --preid=alpha",
     "playground:install": "cd playground && npm install",
     "playground": "cd playground && npm run dev",
-    "playground:build": "cd playground && npm run build"
+    "playground:build": "npm run build && cd playground && npm run build"
   },
   "dependencies": {
     "node-emoji": "^2.1.3",

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@types/node": "^20.14.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1251,6 +1252,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2642,6 +2653,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/node": "^20.14.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -15,8 +15,13 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    // Type-check the playground against the library's PUBLIC built types, not
+    // its source. Vite still aliases the import to ../src for runtime HMR (see
+    // vite.config.ts); this just keeps `tsc -b` from re-checking library
+    // internals under the playground's stricter flags + its own @types/react.
+    // Requires `dist/` to exist — `playground:build` builds the library first.
     "paths": {
-      "slack-blocks-to-jsx": ["../src/index.ts"]
+      "slack-blocks-to-jsx": ["../dist/index.d.ts"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## What

Fix `pnpm playground:build` (it currently fails) and add it to CI so it can't silently rot again.

## Why it was broken

The playground's `tsc -b` resolved `slack-blocks-to-jsx` to the library **source** (`../src/index.ts`) and therefore re-type-checked the whole library under the playground's *stricter* config (`noUnusedLocals`/`noUnusedParameters`) and its own `@types/react@18` — while the repo root currently resolves `@types/react@17` (from dependabot #81). That mix produced ~30 errors (`TS6133` unused-locals in library source, `TS2322` `ReactNode` mismatches) plus 3 `node:path`/`__dirname` errors in `vite.config.ts`. None are real library bugs — `pnpm lint` and `pnpm build` are green.

## Fix

- **`playground/tsconfig.json`** — resolve the package to its **built public types** (`../dist/index.d.ts`) instead of source. The playground now type-checks its own code against the library's public API, not library internals. The Vite alias still points at `../src` for runtime HMR, so the dev experience is unchanged.
- **`package.json`** — `playground:build` now runs the library build first (`npm run build && cd playground && npm run build`), guaranteeing `dist/` exists for the playground's type-check.
- **`playground/package.json`** — add `@types/node` (fixes `vite.config.ts`'s `node:path` / `__dirname`).
- **`.github/workflows/main.yml`** — add `pnpm playground:install` + `pnpm playground:build` steps after the existing lint/build/test.

## Verification

Locally, mirroring CI: `pnpm install --frozen-lockfile` → `pnpm lint && pnpm build && pnpm test` → `pnpm playground:install` → `pnpm playground:build` all pass; `tsc -b` is clean and Vite builds the bundle.
