### PR TITLE
fix: 🐛 stack rich_text sections on their own lines

### DIFF
--- a/src/components/blocks/rich_text/rich_text.tsx
+++ b/src/components/blocks/rich_text/rich_text.tsx
@@ -173,7 +173,11 @@ const Element = (props: ElementProps) => {
     const { elements } = element;
 
     return (
-      <p className="inline-block slack_blocks_to_jsx__rich_text_section_element">
+      // `block` (not `inline-block`) is load-bearing: Slack renders each section of a
+      // rich_text block on its own line, and the parent is a plain div with no column
+      // layout, so inline-block sections would flow onto a single line. Empty sections —
+      // which Slack emits between lines — stay zero-height as blocks, matching Slack.
+      <p className="block slack_blocks_to_jsx__rich_text_section_element">
         {elements.map((el, i) => {
           return <RichTextSectionElement key={`${el.type}__${i}`} element={el} />;
         })}

--- a/test/rich_text_section.test.mjs
+++ b/test/rich_text_section.test.mjs
@@ -1,0 +1,100 @@
+// A rich_text block's `rich_text_section` children are separate lines in Slack, but the
+// renderer marked each one `inline-block`, so sibling sections flowed onto a single line
+// ("123", "asd", "test" rendered as "123asdtest"). The parent is a plain div with no column
+// layout, so nothing else introduced a break. These lock in the block-level section element,
+// the zero-height empty sections Slack emits between lines, and the branches that were never
+// affected (quote, preformatted, list). Run against the built dist/ via Node's built-in
+// runner (CI builds first).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { Message } from "../dist/index.mjs";
+
+const render = (blocks) =>
+  ReactDOMServer.renderToStaticMarkup(
+    React.createElement(Message, {
+      logo: "logo.png",
+      name: "Tester",
+      theme: "light",
+      blocks,
+    }),
+  );
+
+const section = (text) => ({
+  type: "rich_text_section",
+  elements: text === "" ? [] : [{ type: "text", text }],
+});
+
+const multiline = {
+  type: "rich_text",
+  block_id: "multiline",
+  elements: [section("123"), section("asd"), section("test")],
+};
+
+test("sibling sections are block-level so each renders on its own line", () => {
+  const out = render([multiline]);
+  const sections = out.match(/<p class="[^"]*slack_blocks_to_jsx__rich_text_section_element"/g);
+
+  assert.equal(sections?.length, 3);
+  for (const tag of sections) {
+    assert.match(tag, /class="block /);
+    // inline-block was the bug: it flowed the sections onto one line.
+    assert.doesNotMatch(tag, /inline-block/);
+  }
+});
+
+test("section text keeps its order inside the rich_text container", () => {
+  const out = render([multiline]);
+  assert.match(out, /<div id="multiline" class="slack_blocks_to_jsx__rich_text">/);
+  assert.match(out, /123[\s\S]*asd[\s\S]*test/);
+});
+
+test("empty sections Slack emits between lines render as empty block paragraphs", () => {
+  const out = render([
+    {
+      type: "rich_text",
+      elements: [section("first"), section(""), section("second")],
+    },
+  ]);
+
+  // no content and no styling of its own, so an empty section collapses to zero height
+  assert.match(out, /<p class="block slack_blocks_to_jsx__rich_text_section_element"><\/p>/);
+});
+
+test("quote and preformatted branches are untouched", () => {
+  const out = render([
+    {
+      type: "rich_text",
+      elements: [
+        section("line"),
+        { type: "rich_text_quote", elements: [{ type: "text", text: "quoted" }] },
+        { type: "rich_text_preformatted", elements: [{ type: "text", text: "code" }] },
+      ],
+    },
+  ]);
+
+  assert.match(out, /<blockquote[^>]*slack_blocks_to_jsx__rich_text_quote_element/);
+  assert.match(out, /quoted/);
+  assert.match(out, /slack_blocks_to_jsx__rich_text_preformatted_element/);
+  assert.match(out, /code/);
+});
+
+test("sections nested in list items still render their content", () => {
+  const out = render([
+    {
+      type: "rich_text",
+      elements: [
+        {
+          type: "rich_text_list",
+          style: "bullet",
+          elements: [section("one"), section("two")],
+        },
+      ],
+    },
+  ]);
+
+  assert.match(out, /slack_blocks_to_jsx__rich_text_list_element/);
+  assert.match(out, /one[\s\S]*two/);
+});


### PR DESCRIPTION
## Problem

A `rich_text` block with several `rich_text_section` children renders them all on one line: `123`, `asd`, `test` preview as `123asdtest`. Slack renders each section as its own line, so the sent message is correct and only the preview is wrong (reported against `slack-blocks-to-jsx@1.1.1`).

The `rich_text_section` branch of the renderer returned an `inline-block` element:

```tsx
<p className="inline-block slack_blocks_to_jsx__rich_text_section_element">
```

`inline-block` makes sibling sections flow inline instead of stacking, and the parent is a plain `<div class="slack_blocks_to_jsx__rich_text">` with no column layout, so nothing else introduces a break. `rich_text_quote` was never affected because that branch returns a block-level `<blockquote>` — which is why a quote line renders correctly alongside broken section lines.

## Fix

`src/components/blocks/rich_text/rich_text.tsx` — render the section element as `block` instead of `inline-block`, with a short comment so it doesn't get "cleaned up" later (a `<p>` looks block by default, but the Tailwind utility is what wins here).

Empty `rich_text_section` entries (`"elements": []`), which Slack emits between lines, collapse to zero height as blocks — matching Slack, where they render as nothing.

## Verification

Measured in Chromium against the built `dist/style.css`, rendering the reported blocks (three sections separated by the empty sections Slack emits, plus a quote):

| | `123` | `asd` | `test` |
| --- | --- | --- | --- |
| before (`inline-block`) | `top: 26` | `top: 26` | `top: 26` |
| after (`block`) | `top: 26` | `top: 48` | `top: 70` |

Before, the container's text content read `123asdtesta quote line`. After, the three sections occupy three distinct lines and every empty section measures `height: 0`.

New `test/rich_text_section.test.mjs` locks this in against the built `dist/` like the other suites: block-level sections, ordering inside the container, empty sections rendering as empty paragraphs, quote/preformatted branches untouched, and sections nested in list items still rendering. Both layout assertions fail on the pre-fix build and pass after.

`tsc`, `tsup` + `postcss` build, and the full 24-test suite pass locally.

## Compatibility

Consumers who worked around this on 1.1.1 with the documented-style CSS hook:

```css
.slack_blocks_to_jsx__rich_text > .slack_blocks_to_jsx__rich_text_section_element {
  display: block;
}
```

are unaffected — their override now sets the same value as the default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPrRsue6LbUeuAHxAMqtnW)_