### PR TITLE
fix: 🐛 stop bullet lists from seeding ordered list numbering

### DIFF
--- a/src/components/blocks/rich_text/rich_text.tsx
+++ b/src/components/blocks/rich_text/rich_text.tsx
@@ -40,8 +40,16 @@ export const RichText = (props: RichTextProps) => {
             _consecutive_index_map[i as NonNullable<RichTextList["indent"]>] = 0;
           }
 
-          _local_index = _consecutive_index_map[indent];
-          _consecutive_index_map[indent] += element.elements.length;
+          if (element.style === "ordered") {
+            _local_index = _consecutive_index_map[indent];
+            _consecutive_index_map[indent] += element.elements.length;
+          } else {
+            // Only ordered lists carry a running count — Slack splits one ordered list
+            // into several rich_text_list elements when the indent changes, and the count
+            // is what makes the outer level resume at the right number. A bullet list at
+            // this indent is a different list, so it ends that run instead of extending it.
+            _consecutive_index_map[indent] = 0;
+          }
         }
 
         return (

--- a/test/rich_text_list.test.mjs
+++ b/test/rich_text_list.test.mjs
@@ -1,0 +1,88 @@
+// Ordered lists carry a running count across sibling `rich_text_list` elements, because Slack
+// splits one ordered list into several of them when the indent changes — the count is what makes
+// the outer level resume at 3 after a nested a./b. The count was keyed on indent alone, so a
+// bullet list at the same indent fed it too: two bullets followed by an ordered list numbered
+// that list 3., 4. instead of 1., 2. These lock in the restart and the continuation cases it
+// must not break. Run against the built dist/ via Node's built-in runner (CI builds first).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { Message } from "../dist/index.mjs";
+
+const section = (text) => ({
+  type: "rich_text_section",
+  elements: [{ type: "text", text }],
+});
+
+const list = (style, count, { indent, offset } = {}) => {
+  const element = {
+    type: "rich_text_list",
+    style,
+    elements: Array.from({ length: count }, (_, i) => section(`${style} ${i + 1}`)),
+  };
+  if (indent !== undefined) element.indent = indent;
+  if (offset !== undefined) element.offset = offset;
+  return element;
+};
+
+// The markers ("1.", "a.", or a bullet dot) share one span; bullets hold a nested span
+// rather than text, so they come back empty and drop out.
+const markers = (elements) => {
+  const out = ReactDOMServer.renderToStaticMarkup(
+    React.createElement(Message, {
+      logo: "logo.png",
+      name: "Tester",
+      theme: "light",
+      blocks: [{ type: "rich_text", elements }],
+    }),
+  );
+
+  return (out.match(/justify-center">([^<]*)</g) || [])
+    .map((m) => m.slice('justify-center">'.length, -1))
+    .filter(Boolean);
+};
+
+test("a bullet list does not seed the numbering of a following ordered list", () => {
+  // the bug: the two bullets left the indent-0 counter at 2, so this numbered 3., 4.
+  assert.deepEqual(markers([list("bullet", 2), list("ordered", 2)]), ["1.", "2."]);
+});
+
+test("an ordered list interrupted by a bullet list restarts", () => {
+  assert.deepEqual(markers([list("ordered", 2), list("bullet", 2), list("ordered", 2)]), [
+    "1.",
+    "2.",
+    "1.",
+    "2.",
+  ]);
+});
+
+test("an ordered list split by a deeper indent resumes at the next number", () => {
+  // this is what the running count exists for — Slack sends the outer level as two elements
+  assert.deepEqual(
+    markers([
+      list("ordered", 2, { indent: 0 }),
+      list("ordered", 1, { indent: 1 }),
+      list("ordered", 1, { indent: 0 }),
+    ]),
+    ["1.", "2.", "a.", "3."],
+  );
+});
+
+test("consecutive ordered lists at the same indent keep counting", () => {
+  assert.deepEqual(markers([list("ordered", 2), list("ordered", 2)]), ["1.", "2.", "3.", "4."]);
+});
+
+test("a non-list element between two ordered lists restarts numbering", () => {
+  assert.deepEqual(markers([list("ordered", 2), section("interrupting line"), list("ordered", 2)]), [
+    "1.",
+    "2.",
+    "1.",
+    "2.",
+  ]);
+});
+
+test("offset still sets the starting number", () => {
+  assert.deepEqual(markers([list("ordered", 2, { indent: 0, offset: 5 })]), ["6.", "7."]);
+});


### PR DESCRIPTION
## Problem

A bulleted list followed by a numbered list in the same `rich_text` block numbers the ordered list `3.`, `4.` instead of `1.`, `2.`:

```json
[
  { "type": "rich_text_list", "style": "bullet",  "elements": [ /* 2 items */ ] },
  { "type": "rich_text_list", "style": "ordered", "elements": [ /* 2 items */ ] }
]
```

Sibling `rich_text_list` elements share a running count per indent level (`src/components/blocks/rich_text/rich_text.tsx:43`). That count exists for a good reason: Slack splits a single ordered list into several `rich_text_list` elements when the indent changes, and the count is what makes the outer level resume at `3.` after a nested `a.`/`b.`. But it was keyed on indent alone, so bullet lists advanced it too — even though a bullet never renders a number. Whatever bullets counted then leaked into the next ordered list at that indent.

## Fix

Only ordered lists advance the count. A bullet list at that indent ends the run instead of extending it, since it is a different list.

## Verification

New `test/rich_text_list.test.mjs` covers the restart cases and — just as importantly — the continuation cases the count exists for:

| case | markers |
| --- | --- |
| bullet ×2, then ordered ×2 | `1. 2.` (was `3. 4.`) |
| ordered ×2, bullet ×2, ordered ×2 | `1. 2.` … `1. 2.` (was `3. 4.`) |
| ordered ×2 → indent 1 → back to indent 0 | `1. 2. a. 3.` |
| two consecutive ordered lists, same indent | `1. 2. 3. 4.` |
| ordered ×2, a section, ordered ×2 | `1. 2.` … `1. 2.` |
| ordered ×2 with `offset: 5` | `6. 7.` |

The two restart assertions fail on a pre-fix build and the four continuation assertions pass on both, so the change is scoped to the bug and leaves the indent-split behaviour from `7c9d24c` intact.

Full suite: 30/30, plus `tsc` and the `tsup` + `postcss` build clean.

## Notes

Found while testing #100 — unrelated to that fix, so it is its own change on top of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPrRsue6LbUeuAHxAMqtnW)_