### PR TITLE
fix: 🐛 match release-please tags to the repo's existing v* tags

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,3 +115,9 @@ install the **pkg.pr.new GitHub App** → <https://github.com/apps/pkg-pr-new>.
   commits a release PR gathers have already been tested.
 - The release PR is created by the default `GITHUB_TOKEN`, so it does not itself trigger
   the CI workflow — that's why the publish job re-runs the checks.
+- `"include-component-in-tag": false` in `release-please-config.json` is load-bearing, and
+  JSON can't hold a comment explaining it. Without it, release-please looks for tags named
+  `slack-blocks-to-jsx-v1.1.1`, finds none — this repo's tags are `v1.1.1`, from years of
+  the manual script — concludes nothing has ever been released, and walks the whole history:
+  a changelog listing every commit back to v0, and a version bumped off long-released
+  `feat:` commits. Keep the tag format matching the tags that already exist.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node"


### PR DESCRIPTION
Fixes the first release PR (#103), which proposed **1.2.0** with a changelog listing the entire history of the repo — every commit back to `✨ release v1` and `setup tailwindcss`.

## Cause

release-please defaults to **component-prefixed tags**. The proof is in the compare link it generated in that changelog:

```
compare/slack-blocks-to-jsx-v1.1.1...slack-blocks-to-jsx-v1.2.0
```

This repo's tags are plain `v1.1.1` — twelve of them (`v0.8.3` … `v1.1.1`), all cut by `scripts/release.mjs`. release-please found no tag under the name it expected, concluded nothing had ever been released, and walked the full history. Old `feat:` commits shipped back in 1.0.x and 1.1.0 got counted again, which is what turned two `fix:` commits into a minor bump.

block-kitchen doesn't hit this because it has been on release-please since the start — its tags have always been `block-kitchen-v0.9.9`, so the default matches. Porting the config to a repo with existing `v*` tags is what exposed it.

## Fix

```diff
  {
    "$schema": "…/schemas/config.json",
+   "include-component-in-tag": false,
    "packages": {
      ".": { "release-type": "node" }
    }
  }
```

release-please now looks for `v1.1.1`, finds it, and considers only the commits after it — the two merged `fix:` commits — so the next release PR should propose **1.1.2** with a changelog of just those two entries. Tags stay `vX.Y.Z`, consistent with every existing tag and with what the manual fallback script produces.

The reasoning is written into `RELEASING.md` rather than the config, since JSON can't carry a comment and a bare `include-component-in-tag: false` reads like a line worth deleting.

## After this merges

PR #103 is superseded — it proposes the wrong version off a bogus changelog and must not be merged. Merging this should produce a fresh release PR at 1.1.2; #103 should be closed.

## Verification

Config parses and the flag reads back as `false`. The behaviour itself can only be confirmed by the workflow running on `main` — same as the original port. I'll check the regenerated release PR proposes 1.1.2 with a two-entry changelog and report back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPrRsue6LbUeuAHxAMqtnW)_