### PR TITLE
docs: 📝 add npm version badge to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Slack Blocks to JSX
 
+[![npm version](https://img.shields.io/npm/v/slack-blocks-to-jsx)](https://www.npmjs.com/package/slack-blocks-to-jsx)
+
 A React library that renders Slack Block Kit components as JSX with pixel-perfect styling. Full parity with Slack's Block Kit specification.
 
 **[🎮 Live Playground](https://slack-block-to-jsx-playground.vercel.app/)** | **[📖 Blog Post](https://themashcodee.hashnode.dev/how-to-effortlessly-render-slack-blocks-in-react-with-slack-blocks-to-jsx)** | **[📦 NPM](https://www.npmjs.com/package/slack-blocks-to-jsx)**


### PR DESCRIPTION
Adds an npm version badge under the readme title, so the currently published version is visible at a glance and links straight to the package.

```markdown
[[npm version](https://img.shields.io/npm/v/slack-blocks-to-jsx)](https://www.npmjs.com/package/slack-blocks-to-jsx)
```

It reads the version live from the npm registry, so it tracks releases on its own — nothing to update when a new version ships. Right now it renders `1.1.2`.

Placed above the description, leaving the existing Playground / Blog Post / NPM link row untouched.

## Notes

- Committed as `docs:` deliberately: a badge shouldn't bump the package version, and release-please doesn't cut a release for a `docs:` commit on its own. It'll ride along in the changelog of whatever release comes next.
- I could not fetch `img.shields.io` from this sandbox to confirm the image renders — the egress proxy blocks it (`HTTP 403`). The URL follows shields.io's standard `npm/v/<package>` form and the package resolves on the registry, but the render itself is unverified. Worth a glance at the readme preview.
- Happy to add downloads, license, or bundle-size badges alongside it if you want a fuller row — I kept it to the one you asked for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPrRsue6LbUeuAHxAMqtnW)_