### PR TITLE
fix: harden the playground's ?package= build loader

### DIFF
--- a/.github/workflows/playground-comment.yml
+++ b/.github/workflows/playground-comment.yml
@@ -26,23 +26,28 @@ jobs:
           script: |
             const pr = context.issue.number;
             const author = context.payload.pull_request.user.login;
-            // The playground's ?package= override loads this build; ?pr= adds the
-            // one-click "pkg.pr #N" preset. It accepts the pkg.pr.new build URL and
-            // routes it through esm.sh to make it browser-loadable.
+            // The deployed playground is NOT built from this repo's playground/ directory,
+            // so it does not read the ?package= / ?pr= params that playground/src/App.tsx
+            // supports — a link carrying them is silently ignored. It does have a "Library
+            // package" field and a "Load build" button, so link to it bare and tell the
+            // reviewer to paste. If the deployment is ever pointed at playground/, switch
+            // this back to a ?package= link that pre-loads the build.
             const build = `https://pkg.pr.new/slack-blocks-to-jsx@${pr}`;
-            const playground = `https://slack-block-to-jsx-playground.vercel.app/?package=${encodeURIComponent(build)}&pr=${pr}`;
+            const playground = `https://slack-block-to-jsx-playground.vercel.app/`;
             const body = [
               `### 🛝 Playground Preview`,
               ``,
               `👋 Thanks for the PR, @${author}!`,
               ``,
               `You can try these changes **live, before any release** — no install needed.`,
-              `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground with this PR's build pre-loaded:`,
+              `Once the preview build finishes (see the **pkg-pr-new** bot comment), open the playground and load this PR's build:`,
               ``,
               `🛝 **Playground:** ${playground}`,
               `📦 **This PR's build:** \`${build}\``,
               ``,
-              `Paste the build URL into the **Library package** field (or hit the **pkg.pr #${pr}** preset) and click **Load build** — your blocks render against this exact PR. 🎉`,
+              `Paste the build URL into the **Library package** field and click **Load build** — your blocks then render against this exact PR. 🎉`,
+              ``,
+              `> ⚠️ This swaps the library's **JavaScript** only — styling still comes from the playground's bundled CSS, so a PR that changes \`style.css\` won't be fully reflected.`,
             ].join("\n");
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,3 +1,8 @@
 node_modules
 dist
 .vite
+
+# `tsc -b` (via `pnpm playground:build`) emits these next to their sources
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -20,22 +20,47 @@ const PRESET_BUILD = PR_NUMBER ? `https://pkg.pr.new/${PKG}@${PR_NUMBER}` : null
 const REACT_URL = "https://esm.sh/react@18.3.1";
 const REACT_DOM_URL = "https://esm.sh/react-dom@18.3.1/client";
 
-// Turn a field value — a version (`1.1.0`), a pkg.pr.new build URL, or any ESM
+// The build URL is loaded with import(), so it must not be attacker-controlled:
+// ?package= comes from the query string, and anyone can hand out a crafted link.
+// Restricting the host to the two CDNs this feature actually needs keeps a link
+// from running arbitrary JS on the playground's origin.
+const ALLOWED_HOSTS = new Set(["esm.sh", "pkg.pr.new"]);
+const DEPS = "deps=react@18.3.1,react-dom@18.3.1";
+
+// pkg.pr.new spells a build as `<pkg>@<ref>` or `<owner>/<repo>/<pkg>@<ref>`, while
+// esm.sh's /pr/ endpoint always wants the fully-qualified `<owner>/<repo>/<pkg>@<ref>`.
+// Normalizing on the last path segment maps every spelling onto that one shape.
+const toEsmPrUrl = (u: URL): string =>
+  `https://esm.sh/pr/${REPO}/${u.pathname.split("/").filter(Boolean).pop()}`;
+
+type Resolved = { url: string } | { error: string };
+
+// Turn a field value — a version (`1.1.0`), a pkg.pr.new build URL, or an esm.sh
 // URL — into a browser-loadable esm.sh module URL with React pinned.
-const resolveBuildUrl = (pkg: string): string => {
+const resolveBuildUrl = (pkg: string): Resolved => {
   let base: string;
-  if (pkg.startsWith("https://pkg.pr.new/")) {
+
+  if (/^https?:\/\//i.test(pkg)) {
+    let parsed: URL;
+    try {
+      parsed = new URL(pkg);
+    } catch {
+      return { error: `Not a valid URL: ${pkg}` };
+    }
+    if (!ALLOWED_HOSTS.has(parsed.hostname)) {
+      return {
+        error: `Only esm.sh and pkg.pr.new builds can be loaded (got ${parsed.hostname}).`,
+      };
+    }
     // A pkg.pr.new tarball isn't browser-ESM; route it through esm.sh's /pr/.
-    // Compact form (`pkg@ref`) lacks the owner/repo esm.sh needs, so add it.
-    const rest = pkg.slice("https://pkg.pr.new/".length);
-    base = rest.includes("/") ? `https://esm.sh/pr/${rest}` : `https://esm.sh/pr/${REPO}/${rest}`;
-  } else if (/^https?:\/\//.test(pkg)) {
-    base = pkg;
+    base = parsed.hostname === "pkg.pr.new" ? toEsmPrUrl(parsed) : parsed.href;
   } else {
-    const version = pkg.includes("@") ? pkg.slice(pkg.lastIndexOf("@") + 1) : pkg;
+    // A bare version (`1.1.0`), or the redundant `slack-blocks-to-jsx@1.1.0` spelling.
+    const version = pkg.startsWith(`${PKG}@`) ? pkg.slice(PKG.length + 1) : pkg;
     base = `https://esm.sh/${PKG}@${version}`;
   }
-  return base + (base.includes("?") ? "&" : "?") + "deps=react@18.3.1,react-dom@18.3.1";
+
+  return { url: base + (base.includes("?") ? "&" : "?") + DEPS };
 };
 
 // A 1x1 transparent pixel so <Message>'s required `logo` prop has something
@@ -85,12 +110,27 @@ const OverrideMessage = ({ url, blocks, theme }: { url: string; blocks: Block[];
     ])
       .then(([mod, react, reactDom]) => {
         if (cancelled || !containerRef.current) return;
+        if (!mod.Message) {
+          setStatus({ error: `That build doesn't export "Message".` });
+          return;
+        }
         const R = react.default ?? react;
         const createRoot = reactDom.createRoot ?? reactDom.default.createRoot;
         runtimeRef.current = { R, root: createRoot(containerRef.current), Message: mod.Message };
         setStatus("ready");
       })
-      .catch((err: Error) => !cancelled && setStatus({ error: err.message }));
+      .catch((err: Error) => {
+        if (cancelled) return;
+        // A PR's preview build is published by a separate workflow, so the link in
+        // the PR comment can be clicked before the build exists. The native message
+        // for that ("Failed to fetch dynamically imported module") explains nothing.
+        const notPublished = /dynamically imported module|failed to fetch/i.test(err.message);
+        setStatus({
+          error: notPublished
+            ? "Couldn't fetch that build. If this is a PR preview, wait for the pkg-pr-new bot comment to appear, then reload."
+            : err.message,
+        });
+      });
     return () => {
       cancelled = true;
       runtimeRef.current?.root.unmount();
@@ -166,7 +206,7 @@ export const App = () => {
     window.history.replaceState(null, "", url);
   };
 
-  const overrideUrl = useMemo(
+  const resolved = useMemo(
     () => (activePkg ? resolveBuildUrl(activePkg) : null),
     [activePkg],
   );
@@ -241,7 +281,7 @@ export const App = () => {
               pkg.pr #{PR_NUMBER}
             </button>
           )}
-          {overrideUrl && (
+          {activePkg && (
             <button
               type="button"
               title="Switch back to the local ../src build"
@@ -276,8 +316,10 @@ export const App = () => {
           <section className="pg-preview">
             <div className="pg-preview-surface">
               {blocks ? (
-                overrideUrl ? (
-                  <OverrideMessage url={overrideUrl} blocks={blocks} theme={theme} />
+                resolved && "error" in resolved ? (
+                  <div className="pg-editor-error">{resolved.error}</div>
+                ) : resolved ? (
+                  <OverrideMessage url={resolved.url} blocks={blocks} theme={theme} />
                 ) : (
                   <Message
                     blocks={blocks}

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -164,6 +164,8 @@ body.pg-dark .pg-theme-btn.is-active {
   padding: 10px 16px;
   display: flex;
   align-items: center;
+  /* The package field plus its buttons overflow a narrow viewport on one line. */
+  flex-wrap: wrap;
   gap: 12px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   background: #ffffff;
@@ -199,7 +201,7 @@ body.pg-dark .pg-toolbar button {
 }
 
 .pg-toolbar .pg-pkg-input {
-  width: 280px;
+  width: min(280px, 100%);
   padding: 6px 10px;
   border: 1px solid rgba(0, 0, 0, 0.13);
   background: transparent;


### PR DESCRIPTION
Follow-up to #93, which merged its original head — these are the review fixes that weren't in it.

## Security: allowlist build hosts

`?package=` is read from the query string and passed to `import()`, so before this a crafted link ran arbitrary JS on the playground's origin. The host is now restricted to `esm.sh` and `pkg.pr.new`, and a rejection surfaces in the existing error UI rather than throwing inside the render path.

Impact is limited — the playground is public, unauthenticated, and holds nothing but a theme preference — and the deployed site is not built from this directory (see below), so nothing was live-exploitable. It matters for local runs and for wherever this source does get deployed.

## Build URL resolution

- Every pkg.pr.new spelling now maps onto esm.sh's fully-qualified `/pr/<owner>/<repo>/<pkg>@<ref>` form. The previous `includes("/")` test handled the two canonical spellings but emitted a malformed two-segment URL for `<owner>/<pkg>@<ref>`.
- Version parsing keys off an explicit `<pkg>@<version>` prefix instead of `lastIndexOf("@")`, which mangled scoped names.
- `resolveBuildUrl` returns a discriminated `Resolved` union, so a rejection is renderable instead of thrown.

## Error handling

- A build with no `Message` export fails with a readable message rather than throwing during render.
- The opaque "failed to fetch dynamically imported module" is translated into a hint to wait for the preview build to publish — the PR comment can be clicked before `preview.yml` finishes.
- "Use local build" now keys off the requested package rather than the resolved URL, so a rejected value still offers a way back to local.

## Preview comment now matches the deployed playground

The playground at `slack-block-to-jsx-playground.vercel.app` is **not built from this repo's `playground/` directory**. Confirmed two ways: strings in its UI ("Latest npm", "Bundled v1.0.6") appear in zero commits across all branches and tags here, and a hardcoded "pkg.pr #74" preset renders on a URL carrying no `?pr=` param.

So it ignores the `?package=` / `?pr=` params that `playground/src/App.tsx` reads, and #93's pre-loading link silently did nothing. The deployed site does have a "Library package" field and a "Load build" button, so the comment links to it bare and tells the reviewer to paste — which works today. The "pkg.pr #N" preset mention is gone, since the live presets are fixed at #74.

If that deployment is ever pointed at `playground/`, this reverts to a `?package=` link that pre-loads the build; a comment in the workflow says so.

Also notes that only the library's **JavaScript** is swapped — a reviewer checking a `style.css` change would otherwise read the unchanged styling as a pass.

## Housekeeping

Toolbar wraps (the package field and its buttons overflow a narrow viewport), and `tsc -b` artifacts are gitignored.

## Verification

The resolver was extracted verbatim from `App.tsx` and exercised against every input form — both released-version spellings, all three pkg.pr.new spellings collapsing to one esm.sh URL, query-param merging, and rejection of `evil.example` plus the suffix-domain attacks `esm.sh.evil.example` and `pkg.pr.new.evil.example`. 10/10 pass.

Workflow YAML parses, the embedded script passes `node --check`, and the rendered comment body was inspected directly. Playground `tsc -b` and `vite build` exit 0; library tests 30/30.

**Not verified:** the live end-to-end render, since esm.sh is blocked from this environment.